### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 この MCP サーバーは、[ts-morph](https://ts-morph.com/) を利用して TypeScript および JavaScript のコードベースに対するリファクタリング操作を提供します。
 Cursor などのエディタ拡張機能と連携し、シンボル名の変更、ファイル/フォルダ名の変更、参照箇所の検索などを AST (Abstract Syntax Tree) ベースで行うことができます。
 
+<a href="https://glama.ai/mcp/servers/@SiroSuzume/mcp-ts-morph">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@SiroSuzume/mcp-ts-morph/badge" alt="ts-morph Refactoring Tools MCP server" />
+</a>
+
 ## 環境構築
 
 `mcp.json` に以下のように設定を追加します。


### PR DESCRIPTION
This PR adds a badge for the [MCP ts-morph Refactoring Tools](https://glama.ai/mcp/servers/@SiroSuzume/mcp-ts-morph) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@SiroSuzume/mcp-ts-morph">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@SiroSuzume/mcp-ts-morph/badge" alt="ts-morph Refactoring Tools MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.