### PR TITLE
MCPサーバーSDKを最新版に更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 概要
+
+MCP ts-morph Refactoring Tools - ts-morphを利用したTypeScript/JavaScriptのリファクタリングツールを提供するMCPサーバー。
+
+## 開発コマンド
+
+### ビルド
+```bash
+pnpm build        # TypeScriptをコンパイル（dist/に出力）
+pnpm clean        # distディレクトリをクリーン
+```
+
+### テスト
+```bash
+pnpm test         # テスト実行（単一スレッドで実行）
+pnpm test:watch   # ウォッチモードでテスト実行
+pnpm test -- path/to/test.ts  # 特定のテストファイルを実行
+```
+
+### 型チェック・リント・フォーマット
+```bash
+pnpm check-types  # TypeScriptの型チェック（コンパイルなし）
+pnpm lint         # Biomeでリントチェック
+pnpm lint:fix     # Biomeでリント修正
+pnpm format       # Biomeでコードフォーマット
+```
+
+### デバッグ
+```bash
+pnpm inspector    # MCP Inspectorでデバッグ実行
+```
+
+## プロジェクト構造
+
+### コアアーキテクチャ
+
+1. **エントリーポイント**: `src/index.ts`
+   - MCPサーバーのエントリーポイント
+   - STDIOサーバーを起動
+
+2. **MCPレイヤー** (`src/mcp/`)
+   - `stdio.ts`: STDIOサーバーの実装
+   - `config.ts`: サーバー設定
+   - `tools/`: MCPツールの登録と実装
+     - 各ツールは`register-*.ts`として実装
+     - `ts-morph-tools.ts`で全ツールを統合
+
+3. **ts-morphレイヤー** (`src/ts-morph/`)
+   - 実際のリファクタリング処理を実装
+   - 各機能は独立したモジュールとして実装：
+     - `rename-file-system/`: ファイル/フォルダのリネーム
+     - `remove-path-alias/`: パスエイリアスの削除
+     - `find-references.ts`: 参照検索
+     - `move-symbol-to-file/`: シンボルのファイル間移動
+     - `rename-symbol/`: シンボル名の変更
+   - `_utils/`: 共通ユーティリティ
+     - `ts-morph-project.ts`: プロジェクト作成の共通処理
+
+4. **ユーティリティ** (`src/utils/`)
+   - `logger.ts`: Pinoベースのロガー実装
+   - その他の共通ユーティリティ
+
+5. **エラー処理** (`src/errors/`)
+   - カスタムエラークラスの定義
+
+### テスト構造
+
+- 各機能モジュールには対応する`.test.ts`ファイルが存在
+- テストフレームワーク: Vitest
+- テストサンドボックス: `packages/sandbox/`にテスト用のTypeScriptコード
+
+## 重要な実装パターン
+
+### ts-morphプロジェクトの作成
+```typescript
+// src/ts-morph/_utils/ts-morph-project.ts を使用
+import { createTsMorphProject } from "../_utils/ts-morph-project";
+const project = createTsMorphProject(tsconfigPath);
+```
+
+### MCPツールの登録
+各ツールは以下のパターンで実装：
+1. Zodスキーマでパラメータ定義
+2. ツール実装関数（ts-morphレイヤーを呼び出し）
+3. `server.setRequestHandler`で登録
+
+### エラーハンドリング
+- カスタムエラークラスを使用
+- ロガーでエラー内容を記録
+- MCPエラーレスポンスとして返却
+
+## 開発時の注意事項
+
+### 依存関係
+- Node.js v20.19.0（Voltaで管理）
+- pnpm v10.10.0（packageManagerで指定）
+
+### Git Hooks（lefthook）
+- pre-commit: Biomeでフォーマット自動実行
+- pre-push: フォーマットチェックとテスト実行
+
+### ロギング
+環境変数で制御可能：
+- `LOG_LEVEL`: ログレベル（debug, info, warn, error等）
+- `LOG_OUTPUT`: 出力先（console, file）
+- `LOG_FILE_PATH`: ファイル出力時のパス
+
+### テスト実行の詳細
+- 単一スレッドで実行（`--pool threads --poolOptions.threads.singleThread`）
+- モックは各テスト後に自動リセット
+- 環境変数`API_ADDRESS`がテスト時に設定される
+
+## 主要な機能と実装ファイル
+
+- **シンボル名変更**: `src/ts-morph/rename-symbol/`
+- **ファイル/フォルダ名変更**: `src/ts-morph/rename-file-system/`
+- **参照検索**: `src/ts-morph/find-references.ts`
+- **パスエイリアス削除**: `src/ts-morph/remove-path-alias/`
+- **シンボル移動**: `src/ts-morph/move-symbol-to-file/`
+
+各機能の詳細な仕様はREADME.mdを参照。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sirosuzume/mcp-tsmorph-refactor",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "ts-morph を利用した MCP リファクタリングサーバー",
 	"main": "dist/index.js",
 	"bin": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "latest",
+		"@modelcontextprotocol/sdk": "^1.17.5",
 		"pino": "^9.6.0",
 		"ts-morph": "^25.0.1",
 		"typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: latest
+        specifier: ^1.17.5
         version: 1.17.5
       pino:
         specifier: ^9.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: latest
-        version: 1.10.2
+        version: 1.17.5
       pino:
         specifier: ^9.6.0
         version: 9.6.0
@@ -305,8 +305,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@modelcontextprotocol/sdk@1.10.2':
-    resolution: {integrity: sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==}
+  '@modelcontextprotocol/sdk@1.17.5':
+    resolution: {integrity: sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==}
     engines: {node: '>=18'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -475,6 +475,9 @@ packages:
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -652,8 +655,8 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eventsource-parser@3.0.1:
-    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.6:
@@ -681,9 +684,15 @@ packages:
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
@@ -847,6 +856,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   lefthook-darwin-arm64@1.11.11:
     resolution: {integrity: sha512-E4jbCkSYClOwrMbbDCuTCZcD6PL3w2aJkBVZQAA/0xAcfETKj4ud1Xe3FzqBCHFIs4OJBtI8FUzbyoM+XpgSUA==}
@@ -1077,6 +1089,10 @@ packages:
 
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -1326,6 +1342,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -1597,12 +1616,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@modelcontextprotocol/sdk@1.10.2':
+  '@modelcontextprotocol/sdk@1.17.5':
     dependencies:
+      ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.6
+      eventsource-parser: 3.0.6
       express: 5.1.0
       express-rate-limit: 7.5.0(express@5.1.0)
       pkce-challenge: 5.0.0
@@ -1761,6 +1782,13 @@ snapshots:
     dependencies:
       mime-types: 3.0.1
       negotiator: 1.0.0
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ansi-regex@5.0.1: {}
 
@@ -1939,11 +1967,11 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eventsource-parser@3.0.1: {}
+  eventsource-parser@3.0.6: {}
 
   eventsource@3.0.6:
     dependencies:
-      eventsource-parser: 3.0.1
+      eventsource-parser: 3.0.6
 
   execa@1.0.0:
     dependencies:
@@ -1995,6 +2023,8 @@ snapshots:
 
   fast-copy@3.0.2: {}
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2002,6 +2032,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
 
   fast-redact@3.5.0: {}
 
@@ -2163,6 +2195,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   joycon@3.1.1: {}
+
+  json-schema-traverse@0.4.1: {}
 
   lefthook-darwin-arm64@1.11.11:
     optional: true
@@ -2364,6 +2398,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
+
+  punycode@2.3.1: {}
 
   qs@6.14.0:
     dependencies:
@@ -2633,6 +2669,10 @@ snapshots:
   undici-types@6.21.0: {}
 
   unpipe@1.0.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   vary@1.1.2: {}
 

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -5,7 +5,7 @@ import { registerTsMorphTools } from "./tools/ts-morph-tools";
 export function createMcpServer(): McpServer {
 	const server = new McpServer({
 		name: "mcp-ts-morph",
-		version: "0.2.7",
+		version: "0.2.8",
 		description:
 			"エージェントがより正確な作業をするためのts-morphを利用したリファクタリングツール集",
 	});


### PR DESCRIPTION
## 概要
@modelcontextprotocol/sdk を最新版（v1.17.5）に更新しました。

## 背景
MCPサーバーの初回起動時にツール実行でレスポンスが返ってこない問題が発生していました。調査の結果、SDK Issue #509で類似の問題が報告されており、古いバージョン（v1.10.2）を使用していたため、最新版へのアップデートを実施しました。

## 変更内容
- `package.json`: @modelcontextprotocol/sdk のバージョンを `latest` から `^1.17.5` に固定
- `pnpm-lock.yaml`: 依存関係の更新
- `CLAUDE.md`: プロジェクトのドキュメントファイルを新規作成（開発ガイドライン）

## テスト結果
すべてのテストが成功していることを確認済み：
- ✅ 165テスト合格（1テストスキップ）

## 関連Issue
- modelcontextprotocol/typescript-sdk#509: Tool Handlers Not Invoked with StdioServerTransport on macOS