### PR TITLE
/simplify post-PR#21: 既存ヘルパー活用と冗長コメント削減

### DIFF
--- a/src/ts-morph/_utils/find-declarations-to-update.ts
+++ b/src/ts-morph/_utils/find-declarations-to-update.ts
@@ -35,8 +35,7 @@ export async function findDeclarationsReferencingFile(
 	for (const referencingFile of referencingSourceFiles) {
 		signal?.throwIfAborted();
 		const referencingFilePath = referencingFile.getFilePath();
-		// 1 ファイルの解析失敗で全参照走査を止めたくないため、ファイル単位で warn して継続する。
-		// (silent failure ではなく、対象ファイルが多数あるときの robustness を優先する意図的なフォールバック)
+		// 1 ファイルの解析失敗で全参照走査を止めないための意図的な warn+continue
 		try {
 			const declarations = [
 				...referencingFile.getImportDeclarations(),

--- a/src/ts-morph/_utils/ts-morph-project.ts
+++ b/src/ts-morph/_utils/ts-morph-project.ts
@@ -70,12 +70,6 @@ export function getTsConfigPaths(
 	}
 }
 
-/**
- * tsconfig の paths キーを配列で返す。paths が未設定なら空配列。
- *
- * パスエイリアス判定のループ前に 1 回だけ呼ぶ用途。`isPathAlias` の
- * 引数として使う `aliasKeys` を毎ループ内で再計算するのを防ぐ。
- */
 export function getTsConfigAliasKeys(project: Project): string[] {
 	return Object.keys(getTsConfigPaths(project) ?? {});
 }

--- a/src/ts-morph/move-symbol-to-file/remove-original-symbol.ts
+++ b/src/ts-morph/move-symbol-to-file/remove-original-symbol.ts
@@ -1,6 +1,6 @@
 import type { SourceFile, Statement } from "ts-morph";
-import { SyntaxKind } from "ts-morph";
 import logger from "../../utils/logger";
+import { getDeclarationIdentifier } from "./get-declaration-identifier";
 
 /**
  * 指定された宣言ノード (Statement) をソースファイルから削除します。
@@ -20,8 +20,7 @@ export function removeOriginalSymbol(
 
 	for (const declaration of declarationsToRemove) {
 		const symbolIdentifier =
-			declaration.getFirstDescendantByKind(SyntaxKind.Identifier)?.getText() ??
-			"(unknown)";
+			getDeclarationIdentifier(declaration)?.getText() ?? "(unknown)";
 
 		if (declaration.getParent() !== sourceFile) {
 			logger.warn(


### PR DESCRIPTION
## Summary

PR #21 マージ後に `/simplify` を回して挙がった actionable な指摘 3 件を反映。

- `remove-original-symbol`: 生の `getFirstDescendantByKind(SyntaxKind.Identifier)` を、同 `move-symbol-to-file/` 配下で既に使われている `getDeclarationIdentifier` ヘルパーに置換。decorator や default value 内の Identifier を誤って拾うリスクを回避し、`classify-dependencies.ts` / `internal-dependencies.ts` と整合させる。
- `find-declarations-to-update`: 意図的に残した try/catch (ファイル単位の warn+continue) の解説コメントが 2 行で重複していたため 1 行に圧縮。
- `getTsConfigAliasKeys`: シグネチャから自明な内容を述べる JSDoc を削除。

`removePathAlias` の `paths` → `aliasKeys` 化や `getTsConfigPaths` の export 削除は、レビューでも non-blocking 判定だったため見送り。

## Test plan

- [x] `pnpm check-types` 通過
- [x] `pnpm test` 通過 (199 passed / 1 skipped)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)