### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sirosuzume/mcp-tsmorph-refactor",
-	"version": "0.2.9",
+	"version": "1.0.0",
 	"description": "ts-morph を利用した MCP リファクタリングサーバー",
 	"main": "dist/index.js",
 	"bin": {


### PR DESCRIPTION
## Summary

v1.0.0 タグ push 時に \`package.json\` の version bump が漏れており、release workflow の整合性チェックで失敗 (run 26375661149) したため、\`package.json\` を \`0.2.9\` → \`1.0.0\` に揃える bump-only PR。

## 必要なフォローアップ (マージ後にユーザ側で実施)

1. リモートの既存 \`v1.0.0\` タグを削除
   \`\`\`
   git push origin :refs/tags/v1.0.0
   \`\`\`
2. main に切り替えて pull、bump コミット (\`a6bf42e\` 等) に v1.0.0 タグを付与して push
   \`\`\`
   git switch main && git pull
   git tag v1.0.0
   git push origin v1.0.0
   \`\`\`
3. release workflow が走り npm publish される

## Test plan

- [x] pre-push hook (\`pnpm test\`) 通過
- [ ] CI green
- [ ] マージ後、再 tag push で release workflow が \`Check package version consistency\` を通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)