### PR TITLE
chore(release): migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # npm publish (provenance) のため (推奨)
+      # npm の Trusted Publishing (OIDC) と provenance のために必須。
+      # NPM_TOKEN を廃止し、短命 OIDC ID Token で publish するためここが唯一の認可資産。
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,9 +62,9 @@ jobs:
           echo "package.json version ($PACKAGE_VERSION) matches tag version ($TAG_VERSION)."
 
       - name: Publish to npm
+        # npm Trusted Publishing (OIDC) 経由で publish。
+        # 事前条件: npm 側でこの repo + workflow が Trusted Publisher に登録済みであること。
         # --no-git-checks: CI 環境では Git の状態チェックをスキップ
         # --provenance: npm publish の出所証明を有効化
         # --access public: スコープ付きパッケージを公開
         run: pnpm publish --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

v1.0.0 publish 失敗を機に、長期 secret (NPM_TOKEN) を持たない **npm Trusted Publishing (OIDC)** へ移行する。

### 現状の問題
- 既存 NPM_TOKEN が expire → 404
- 再発行した Granular Access Token は 2FA bypass が無く 403
- Classic Automation Token は 2FA bypass 可能だが long-lived secret として残るため流出リスクが高い
- 2025 年の npm サプライチェーン攻撃多発を踏まえ、token 自体を持たない方式が望ましい

### OIDC Trusted Publishing の利点
- workflow が走る度に発行される **短命 OIDC ID Token** で publish
- GitHub Actions の repo / workflow / branch / tag に scope を絞れる
- GitHub Secret に publish 用 token を保管しない (流出資産そのものが消える)
- token rotation の運用が消える
- npm provenance とも自然に統合

## What

\`\`\`diff
     permissions:
-      id-token: write # npm publish (provenance) のため (推奨)
+      # npm の Trusted Publishing (OIDC) と provenance のために必須。
+      # NPM_TOKEN を廃止し、短命 OIDC ID Token で publish するためここが唯一の認可資産。
+      id-token: write
...
       - name: Publish to npm
         run: pnpm publish --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
\`\`\`

\`id-token: write\` は既に付与済みだったので、env 削除のみが実質変更点。

## ⚠️ マージ前に必要な npm 側の設定

このまま merge → tag rerun すると **OIDC 設定が未登録のため publish が失敗** する。
**マージ前に**以下を実施すること:

1. https://www.npmjs.com/package/@sirosuzume/mcp-tsmorph-refactor/access を開く
2. \`Trusted publishers\` セクションで GitHub Actions を追加
3. 入力値:
   - Owner/Repository: \`SiroSuzume/mcp-ts-morph\`
   - Workflow filename: \`release.yml\`
   - Environment: (空でOK)

## マージ後の手順

1. v1.0.0 タグの workflow を re-run
   \`\`\`bash
   gh run rerun <latest-failed-run-id>
   \`\`\`
   もしくはタグを打ち直し
2. publish 成功を確認: https://www.npmjs.com/package/@sirosuzume/mcp-tsmorph-refactor
3. 古い NPM_TOKEN を npm 側で **Revoke** + GitHub Secret も削除

## Test plan

- [x] pre-push hook (\`pnpm test\`) 通過
- [ ] npm 側で Trusted Publisher 登録完了
- [ ] マージ後 v1.0.0 publish 成功
- [ ] 旧 NPM_TOKEN / GitHub Secret を revoke / 削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)