### PR TITLE
fix(rename): namespace import + path-alias の更新漏れを修正 (closes #26)

### DIFF
--- a/src/ts-morph/rename-file-system/_utils/find-declarations-for-rename-operation.ts
+++ b/src/ts-morph/rename-file-system/_utils/find-declarations-for-rename-operation.ts
@@ -9,13 +9,14 @@ export function findDeclarationsForRenameOperation(
 	signal?: AbortSignal,
 ): Set<ImportDeclaration | ExportDeclaration> {
 	const { sourceFile } = renameOperation;
+	const targetFilePath = sourceFile.getFilePath();
 	const declarationsForThisOperation = new Set<
 		ImportDeclaration | ExportDeclaration
 	>();
 
 	const exportSymbols = sourceFile.getExportSymbols();
 	logger.trace(
-		{ file: sourceFile.getFilePath(), count: exportSymbols.length },
+		{ file: targetFilePath, count: exportSymbols.length },
 		"Found export symbols for rename operation",
 	);
 
@@ -40,6 +41,30 @@ export function findDeclarationsForRenameOperation(
 			for (const decl of foundDecls) {
 				declarationsForThisOperation.add(decl);
 			}
+		}
+	}
+
+	// Namespace import (`import * as X from "..."` / `import type * as X from "..."`)
+	// は import 宣言に被参照シンボル名が現れないため symbol → findReferencesAsNodes
+	// 経路では取りこぼす。referencing source files から module specifier が
+	// 対象ファイルに解決される宣言を直接拾って補完する。
+	const referencingFiles = sourceFile.getReferencingSourceFiles();
+	for (const referencingFile of referencingFiles) {
+		signal?.throwIfAborted();
+		const declarations = [
+			...referencingFile.getImportDeclarations(),
+			...referencingFile.getExportDeclarations(),
+		];
+		for (const declaration of declarations) {
+			signal?.throwIfAborted();
+			if (!declaration.getModuleSpecifier()) continue;
+			if (
+				declaration.getModuleSpecifierSourceFile()?.getFilePath() !==
+				targetFilePath
+			) {
+				continue;
+			}
+			declarationsForThisOperation.add(declaration);
 		}
 	}
 

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
@@ -351,6 +351,92 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 	});
 });
 
+describe("renameFileSystemEntry with type-only namespace import (issue #26)", () => {
+	it("`import type * as X from '@/...'` (type-only namespace import + path-alias) も rename で更新されること", async () => {
+		const project = setupProject();
+		const oldTargetPath = "/src/types/request.ts";
+		const newTargetPath = "/src/typings/request.ts";
+		const usagePath = "/src/usage.ts";
+
+		project.createDirectory("/src/types");
+		project.createSourceFile(
+			oldTargetPath,
+			"export type CreateRequest = { id: string };",
+		);
+		project.createSourceFile(
+			usagePath,
+			`import type * as Req from "@/types/request";
+import type { CreateRequest } from "@/types/request";
+
+export const a: Req.CreateRequest = { id: "x" };
+export const b: CreateRequest = { id: "y" };
+`,
+		);
+
+		await renameFileSystemEntry({
+			project,
+			renames: [{ oldPath: oldTargetPath, newPath: newTargetPath }],
+			dryRun: false,
+		});
+
+		const updatedUsageContent = project
+			.getSourceFileOrThrow(usagePath)
+			.getFullText();
+
+		// (A) type-only namespace import: 旧パスが残っていないこと
+		expect(updatedUsageContent).not.toMatch(
+			/import type \* as Req from ["']@\/types\/request["']/,
+		);
+		expect(updatedUsageContent).toMatch(
+			/import type \* as Req from ["']\.\/typings\/request["']/,
+		);
+		// (B) type-only named import: 既に正しく更新されている (回帰防止)
+		expect(updatedUsageContent).not.toMatch(
+			/import type \{ CreateRequest \} from ["']@\/types\/request["']/,
+		);
+		expect(updatedUsageContent).toMatch(
+			/import type \{ CreateRequest \} from ["']\.\/typings\/request["']/,
+		);
+	});
+
+	it("`import type * as X from './relative'` (type-only namespace import + 相対パス) が rename で更新されること (回帰防止)", async () => {
+		const project = setupProject();
+		const oldTargetPath = "/src/types/request.ts";
+		const newTargetPath = "/src/typings/request.ts";
+		const usagePath = "/src/usage.ts";
+
+		project.createDirectory("/src/types");
+		project.createSourceFile(
+			oldTargetPath,
+			"export type CreateRequest = { id: string };",
+		);
+		project.createSourceFile(
+			usagePath,
+			`import type * as Req from "./types/request";
+
+export const a: Req.CreateRequest = { id: "x" };
+`,
+		);
+
+		await renameFileSystemEntry({
+			project,
+			renames: [{ oldPath: oldTargetPath, newPath: newTargetPath }],
+			dryRun: false,
+		});
+
+		const updatedUsageContent = project
+			.getSourceFileOrThrow(usagePath)
+			.getFullText();
+
+		expect(updatedUsageContent).not.toMatch(
+			/import type \* as Req from ["']\.\/types\/request["']/,
+		);
+		expect(updatedUsageContent).toMatch(
+			/import type \* as Req from ["']\.\/typings\/request["']/,
+		);
+	});
+});
+
 describe("renameFileSystemEntry with index.ts re-exports (actual bug reproduction)", () => {
 	it("index.tsが複数のモジュールを再エクスポートし、そのうちの1つをリネームした際、インポート元のパスがindex.tsを指し続けること", async () => {
 		const project = setupProject();

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
@@ -383,19 +383,14 @@ export const b: CreateRequest = { id: "y" };
 			.getSourceFileOrThrow(usagePath)
 			.getFullText();
 
-		// (A) type-only namespace import: 旧パスが残っていないこと
-		expect(updatedUsageContent).not.toMatch(
-			/import type \* as Req from ["']@\/types\/request["']/,
+		// 旧パスは namespace import (A) / named import (B) 両方から消えていること
+		expect(updatedUsageContent).not.toContain("@/types/request");
+		// 新パスは 2 つの import 文両方に現れていること
+		expect(updatedUsageContent).toContain(
+			'import type * as Req from "./typings/request"',
 		);
-		expect(updatedUsageContent).toMatch(
-			/import type \* as Req from ["']\.\/typings\/request["']/,
-		);
-		// (B) type-only named import: 既に正しく更新されている (回帰防止)
-		expect(updatedUsageContent).not.toMatch(
-			/import type \{ CreateRequest \} from ["']@\/types\/request["']/,
-		);
-		expect(updatedUsageContent).toMatch(
-			/import type \{ CreateRequest \} from ["']\.\/typings\/request["']/,
+		expect(updatedUsageContent).toContain(
+			'import type { CreateRequest } from "./typings/request"',
 		);
 	});
 
@@ -428,11 +423,9 @@ export const a: Req.CreateRequest = { id: "x" };
 			.getSourceFileOrThrow(usagePath)
 			.getFullText();
 
-		expect(updatedUsageContent).not.toMatch(
-			/import type \* as Req from ["']\.\/types\/request["']/,
-		);
-		expect(updatedUsageContent).toMatch(
-			/import type \* as Req from ["']\.\/typings\/request["']/,
+		expect(updatedUsageContent).not.toContain("./types/request");
+		expect(updatedUsageContent).toContain(
+			'import type * as Req from "./typings/request"',
 		);
 	});
 });


### PR DESCRIPTION
## Summary

issue #26 の修正。`rename_filesystem_entry_by_tsmorph` で
`import type * as X from "@/..."` (type-only namespace import + path-alias) が
silent に取りこぼされていた問題を解消する。

closes #26

## 根本原因

`findDeclarationsForRenameOperation` は対象ファイルの export シンボルを起点に
`findReferencesAsNodes()` を呼び、ヒットしたノードの ancestor を辿って
`ImportDeclaration` / `ExportDeclaration` を集める **symbol-base** 検索だった。

\`\`\`ts
// import 宣言に CreateRequest という識別子が現れる → ancestor で ImportDecl に届く
import type { CreateRequest } from "@/types/request";

// import 宣言には Req しか現れない → CreateRequest の参照は Req.CreateRequest の
// 形でしか出ず、ancestor を辿っても ImportDecl には届かない（変数宣言で止まる）
import type * as Req from "@/types/request";
export const a: Req.CreateRequest = { id: "x" };
\`\`\`

namespace import は import 宣言に被参照シンボル名そのものが現れないため、
symbol → findReferencesAsNodes 経路では構造的に取りこぼす。

なお仮説で挙がっていた「\`getModuleSpecifierSourceFile()\` が undefined を返す」は
誤りで、ts-morph は全 4 ケース (relative/alias × named/namespace) で正しく
target ファイルに解決していた。

## 修正

`sourceFile.getReferencingSourceFiles()` を起点とする **file-base** 補完を追加し、
module specifier が対象ファイルに解決される import/export 宣言を直接 Set に追加。

\`\`\`ts
const referencingFiles = sourceFile.getReferencingSourceFiles();
for (const referencingFile of referencingFiles) {
    for (const declaration of [
        ...referencingFile.getImportDeclarations(),
        ...referencingFile.getExportDeclarations(),
    ]) {
        if (!declaration.getModuleSpecifier()) continue;
        if (
            declaration.getModuleSpecifierSourceFile()?.getFilePath() !==
            targetFilePath
        ) continue;
        declarationsForThisOperation.add(declaration);
    }
}
\`\`\`

- 既存の symbol-base 検索（バレル経由の再エクスポートに強い）は維持し、
  union として併存させる。Set なので重複は自動で潰れる
- file-base 検索は namespace import を取りこぼさないため、issue #26 の
  パターンが救われる

## 主な変更内容

| ファイル | 概要 |
|---|---|
| \`src/ts-morph/rename-file-system/_utils/find-declarations-for-rename-operation.ts\` | file-base 補完ループを追加 |
| \`src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts\` | 再現テスト 2 件追加 (path-alias 版・相対パス版) |

## テスト

- [x] 追加した再現テスト 2 件が pass
- [x] \`pnpm test\` 全体 (201 passed, 1 skipped) で regression なし
- [x] \`pnpm check-types\` pass
- [x] \`pnpm lint\` pass

## 残課題 (本 PR スコープ外)

- 同じ rename で発見されたディレクトリ rename 後の空ディレクトリ残存問題は
  別 issue #27 で追跡

🤖 Generated with [Claude Code](https://claude.com/claude-code)