### PR TITLE
fix(rename): ディレクトリ rename 後の空ディレクトリ階層を掃除する (closes #27)

### DIFF
--- a/src/ts-morph/rename-file-system/cleanup-empty-old-directories.ts
+++ b/src/ts-morph/rename-file-system/cleanup-empty-old-directories.ts
@@ -1,0 +1,61 @@
+import type { Project } from "ts-morph";
+import logger from "../../utils/logger";
+import type { PathMapping } from "../types";
+
+/**
+ * directory rename 後、ファイルが全て移動した結果として残った旧ディレクトリ階層を
+ * bottom-up に掃除する (issue #27)。
+ *
+ * sourceFile.move() は親ディレクトリのクリーンアップを行わないため、real FS では
+ * 空ディレクトリが残り、project の Directory 追跡上にも残骸が残る。
+ *
+ * 安全側に倒すルール:
+ *  - FS 上にエントリが残っているディレクトリは触らない (untracked file 保護)
+ *  - 削除は1段ずつ。`Directory.delete()` の再帰削除は untracked を巻き込むので使わない
+ *  - 失敗しても rename 全体は失敗させず warn ログだけ出す (副作用扱い)
+ */
+export function cleanupEmptyOldDirectories(
+	project: Project,
+	directoryRenames: PathMapping[],
+	signal?: AbortSignal,
+): void {
+	if (directoryRenames.length === 0) return;
+	const fs = project.getFileSystem();
+
+	for (const { oldPath } of directoryRenames) {
+		signal?.throwIfAborted();
+		const oldDir = project.getDirectory(oldPath);
+		if (!oldDir) continue;
+
+		// 深い順 (子から親へ) に並べないと、親ディレクトリのチェック時点で
+		// 子が削除されていない → entries 残存 → 親も残ってしまう
+		const candidates = [oldDir, ...oldDir.getDescendantDirectories()].sort(
+			(a, b) => b.getPath().length - a.getPath().length,
+		);
+
+		for (const dir of candidates) {
+			signal?.throwIfAborted();
+			const dirPath = dir.getPath();
+			try {
+				if (!fs.directoryExistsSync(dirPath)) {
+					dir.forget();
+					continue;
+				}
+				const entries = fs.readDirSync(dirPath);
+				if (entries.length > 0) {
+					// untracked ファイル / 想定外のサブディレクトリが残っている。
+					// ここで止めることで親方向の連鎖削除も自動で抑制される
+					logger.trace(
+						{ dirPath, remaining: entries.length },
+						"Skipping cleanup: directory not empty (untracked content)",
+					);
+					continue;
+				}
+				fs.deleteSync(dirPath);
+				dir.forget();
+			} catch (err) {
+				logger.warn({ err, dirPath }, "Failed to cleanup empty old directory");
+			}
+		}
+	}
+}

--- a/src/ts-morph/rename-file-system/prepare-renames.ts
+++ b/src/ts-morph/rename-file-system/prepare-renames.ts
@@ -20,14 +20,24 @@ function checkDestinationExists(
 	}
 }
 
+export interface PrepareRenamesResult {
+	operations: RenameOperation[];
+	/**
+	 * 元入力のうち directory rename だったものの絶対パスペア。
+	 * file move 後に旧ディレクトリ階層の空ディレクトリを掃除するために使う (issue #27)。
+	 */
+	directoryRenames: PathMapping[];
+}
+
 export function prepareRenames(
 	project: Project,
 	renames: PathMapping[],
 	signal?: AbortSignal,
-): RenameOperation[] {
+): PrepareRenamesResult {
 	const startTime = performance.now();
 	signal?.throwIfAborted();
 	const renameOperations: RenameOperation[] = [];
+	const directoryRenames: PathMapping[] = [];
 	const uniqueNewPaths = new Set<string>();
 	logger.debug({ count: renames.length }, "Starting rename preparation");
 
@@ -59,6 +69,10 @@ export function prepareRenames(
 			});
 		} else if (directory) {
 			logger.trace({ path: absoluteOldPath }, "Identified as directory rename");
+			directoryRenames.push({
+				oldPath: absoluteOldPath,
+				newPath: absoluteNewPath,
+			});
 			signal?.throwIfAborted();
 			const filesInDir = directory.getDescendantSourceFiles();
 			logger.trace(
@@ -85,8 +99,12 @@ export function prepareRenames(
 	}
 	const durationMs = (performance.now() - startTime).toFixed(2);
 	logger.debug(
-		{ operationCount: renameOperations.length, durationMs },
+		{
+			operationCount: renameOperations.length,
+			directoryCount: directoryRenames.length,
+			durationMs,
+		},
 		"Finished rename preparation",
 	);
-	return renameOperations;
+	return { operations: renameOperations, directoryRenames };
 }

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.complex.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.complex.test.ts
@@ -123,6 +123,75 @@ describe("renameFileSystemEntry Complex Cases", () => {
 		expect(updatedRef).toContain("import { valComp } from './widgets/comp';");
 	});
 
+	it("ディレクトリ rename 後、旧ディレクトリ階層の空サブディレクトリが残らない (issue #27)", async () => {
+		const project = setupProject();
+		const oldDirPath = "/src/foo";
+		const newDirPath = "/src/bar";
+
+		project.createSourceFile(`${oldDirPath}/index.ts`, "export const a = 1;");
+		project.createSourceFile(
+			`${oldDirPath}/sub-a/index.ts`,
+			"export const b = 2;",
+		);
+		project.createSourceFile(
+			`${oldDirPath}/sub-b/nested/index.ts`,
+			"export const c = 3;",
+		);
+
+		await renameFileSystemEntry({
+			project,
+			renames: [{ oldPath: oldDirPath, newPath: newDirPath }],
+			dryRun: false,
+		});
+
+		// 1. 新しいディレクトリツリーは存在する
+		expect(project.getDirectory(newDirPath)).toBeDefined();
+		expect(
+			project.getSourceFile(`${newDirPath}/sub-b/nested/index.ts`),
+		).toBeDefined();
+
+		// 2. 旧ディレクトリは project tree から消えている (issue #27 の本質)
+		expect(project.getDirectory(oldDirPath)).toBeUndefined();
+		expect(project.getDirectory(`${oldDirPath}/sub-a`)).toBeUndefined();
+		expect(project.getDirectory(`${oldDirPath}/sub-b`)).toBeUndefined();
+		expect(project.getDirectory(`${oldDirPath}/sub-b/nested`)).toBeUndefined();
+	});
+
+	it("ディレクトリ rename 時、untracked ファイルがあるディレクトリは保護される (issue #27)", async () => {
+		const project = setupProject();
+		const oldDirPath = "/src/foo";
+		const newDirPath = "/src/bar";
+
+		project.createSourceFile(`${oldDirPath}/index.ts`, "export const a = 1;");
+		project.createSourceFile(
+			`${oldDirPath}/sub-a/index.ts`,
+			"export const b = 2;",
+		);
+		project.createSourceFile(
+			`${oldDirPath}/sub-b/index.ts`,
+			"export const c = 3;",
+		);
+		// project が把握していない untracked ファイル (README 等を想定)
+		const fs = project.getFileSystem();
+		fs.writeFileSync(`${oldDirPath}/sub-a/README.md`, "# do not delete me");
+
+		await renameFileSystemEntry({
+			project,
+			renames: [{ oldPath: oldDirPath, newPath: newDirPath }],
+			dryRun: false,
+		});
+
+		// untracked を含むディレクトリは残し、ファイル本体も無傷
+		expect(fs.directoryExistsSync(`${oldDirPath}/sub-a`)).toBe(true);
+		expect(fs.readFileSync(`${oldDirPath}/sub-a/README.md`)).toContain(
+			"do not delete me",
+		);
+		// untracked を抱える sub-a を含むので /src/foo 自身も残る
+		expect(fs.directoryExistsSync(oldDirPath)).toBe(true);
+		// untracked のない sub-b は project tree から消える
+		expect(project.getDirectory(`${oldDirPath}/sub-b`)).toBeUndefined();
+	});
+
 	it("ファイル名をスワップする（一時ファイル経由）", async () => {
 		const project = setupProject();
 		const fileA = "/src/fileA.ts";

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
@@ -320,7 +320,7 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 
 		expect(project.getSourceFile(moduleDOriginalPath)).toBeUndefined();
 		expect(project.getSourceFile(indexTsOriginalPath)).toBeUndefined();
-		// expect(project.getDirectory(oldUtilsDir)).toBeUndefined(); // ユーザーの指示によりコメントアウト
+		expect(project.getDirectory(oldUtilsDir)).toBeUndefined();
 
 		expect(project.getDirectory(newUtilsDir)).toBeDefined();
 		expect(project.getSourceFile(moduleDRenamedPath)).toBeDefined();

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.ts
@@ -13,6 +13,7 @@ import type {
 	RenameOperation,
 } from "../types";
 import { isPathAlias } from "../_utils/path-alias";
+import { cleanupEmptyOldDirectories } from "./cleanup-empty-old-directories";
 import { findDeclarationsForRenameOperation } from "./_utils/find-declarations-for-rename-operation";
 import { moveFileSystemEntries } from "./move-file-system-entries";
 import { prepareRenames } from "./prepare-renames";
@@ -146,7 +147,11 @@ export async function renameFileSystemEntry({
 	try {
 		signal?.throwIfAborted();
 
-		const renameOperations = prepareRenames(project, renames, signal);
+		const { operations: renameOperations, directoryRenames } = prepareRenames(
+			project,
+			renames,
+			signal,
+		);
 		signal?.throwIfAborted();
 
 		const allDeclarationsToUpdate = await findAllDeclarationsToUpdate(
@@ -175,6 +180,9 @@ export async function renameFileSystemEntry({
 				},
 				"Saved project changes",
 			);
+			// FS への永続化が完了した後でなければ、旧ディレクトリは依然として
+			// 移動前のファイルを保持しているため readDirSync が空にならない
+			cleanupEmptyOldDirectories(project, directoryRenames, signal);
 		} else if (dryRun) {
 			logger.info({ count: changed.length }, "Dry run: Skipping save");
 		} else {


### PR DESCRIPTION
## Summary

issue #27 の修正。`rename_filesystem_entry_by_tsmorph` でディレクトリを rename したとき、
旧ディレクトリ階層が real FS と project tree の両方に空のまま残り、
git status のノイズ・path-alias 解決時の混乱・後続 grep/IDE 補完の混乱の
原因になっていた問題を解消する。

closes #27

## 根本原因

\`prepareRenames\` がディレクトリ rename を per-file の \`sourceFile.move()\` に
展開していたが、ts-morph の \`sourceFile.move()\` は **親ディレクトリのクリーンアップを
一切行わない**。結果として:

- 旧ディレクトリ自身 + 全サブディレクトリが real FS に空のまま残る (\`find -type d -empty\`)
- \`project.getDirectory(oldPath)\` も Directory オブジェクトを保持し続ける
  (in-memory FS でも project tree 上の追跡だけは残る)

実測: 22 ファイル + 7 サブディレクトリの \`src/types/\` を \`src/typings/\` に rename した
ケースで、11 個の空サブディレクトリが残存。

## 修正

\`\`\`
prepareRenames
  └─ operations: per-file moves
  └─ directoryRenames: 元入力の directory rename ペア (NEW)

renameFileSystemEntry
  ├─ moveFileSystemEntries (既存)
  ├─ updateModuleSpecifiers (既存)
  ├─ saveProjectChanges (既存; ここで FS に書き込まれる)
  └─ cleanupEmptyOldDirectories (NEW)
\`\`\`

\`cleanupEmptyOldDirectories\` の挙動:

1. directory rename ごとに旧 \`Directory\` + descendant Directories を **bottom-up** (deepest first) で並べる
2. 各 dir で \`fs.directoryExistsSync\` → 存在しなければ \`dir.forget()\` だけ
3. \`fs.readDirSync\` でエントリ数を確認 → **0 件なら** \`fs.deleteSync\` + \`forget()\`
4. **0 件でなければスキップ** — untracked ファイルがある階層は触らず、親方向の連鎖削除も自動で抑制される
5. 失敗は \`warn\` ログのみ。rename 全体は落とさない (副作用扱い)

### 安全上のポイント

- \`Directory.delete()\` / \`deleteImmediately()\` は再帰削除になるため **使わない**。
  untracked file (README.md, .DS_Store, generated 物) を巻き込む危険があるため
- bottom-up + 1段ずつの \`deleteSync\` で「空が確認できた階層のみ」削除
- dryRun 時は \`saveProjectChanges\` 自体が走らないので cleanup も実行されない (FS に書いていない以上、空ディレクトリは存在しない)

## 主な変更内容

| ファイル | 概要 |
|---|---|
| \`src/ts-morph/rename-file-system/prepare-renames.ts\` | 戻り値を \`{ operations, directoryRenames }\` に拡張 |
| \`src/ts-morph/rename-file-system/cleanup-empty-old-directories.ts\` (新規) | bottom-up に空ディレクトリを削除する util |
| \`src/ts-morph/rename-file-system/rename-file-system-entry.ts\` | save 後に cleanup を呼び出し |
| \`src/ts-morph/rename-file-system/rename-file-system-entry.complex.test.ts\` | 再現テスト 2 件追加 (基本ケース + untracked 保護) |
| \`src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts\` | 過去にコメントアウトされていた \`oldUtilsDir.toBeUndefined()\` を有効化 |

## テスト

- [x] 追加した再現テスト 2 件 pass
- [x] 過去にコメントアウトされていた assertion を有効化、pass
- [x] \`pnpm test\` 25 ファイル / 203 tests pass (1 skipped, 既存 skip)
- [x] \`pnpm check-types\` pass
- [x] \`pnpm lint\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)