### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sirosuzume/mcp-tsmorph-refactor",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "ts-morph を利用した MCP リファクタリングサーバー",
 	"main": "dist/index.js",
 	"bin": {


### PR DESCRIPTION
## Summary

v1.0.0 → v1.1.0 への version bump 専用 PR。

既に push 済みの **v1.0.1 / v1.1.0 タグは release CI で version 整合性エラー失敗** している (package.json は 1.0.0 のまま)。本 PR をマージした後、壊れたタグを削除 → 新 main HEAD に v1.1.0 を再タグする必要あり。

## 含まれる変更 (v1.0.0 以降)

| PR | 種別 | 概要 |
|---|---|---|
| #28 | fix (#26) | type-only namespace import + path-alias が rename で更新漏れする bug 修正 |
| #29 | fix (#27) | ディレクトリ rename 後の空サブディレクトリ残存 bug 修正 |
| #30 | perf | ts-morph の auto-reference-update を bypass し rename を 8.6 倍速化 + shell mv セマンティクスに変更 |

PR #30 でディレクトリ rename が shell `mv` セマンティクスに変わる behavioral change を含むため **MINOR bump (1.1.0)** が妥当。

## マージ後の手順 (要ユーザ操作)

\`\`\`bash
# 1. 壊れた既存タグ + GitHub release を削除
git push origin :refs/tags/v1.0.1
git push origin :refs/tags/v1.1.0
gh release delete v1.0.1 --yes --cleanup-tag
gh release delete v1.1.0 --yes --cleanup-tag

# 2. main を最新化
git checkout main && git pull origin main

# 3. v1.1.0 を再タグして push (release CI を triggers)
git tag v1.1.0
git push origin v1.1.0
\`\`\`

v1.0.1 は v1.1.0 に内包されるため **発行不要 (スキップ)**。

## 変更内容

\`\`\`diff
- "version": "1.0.0",
+ "version": "1.1.0",
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)