### PR TITLE
docs(tools): MCP ツール description を agent 向けに統一テンプレで再構成

### DIFF
--- a/src/mcp/tools/register-find-references-tool.ts
+++ b/src/mcp/tools/register-find-references-tool.ts
@@ -6,30 +6,23 @@ import { performance } from "node:perf_hooks";
 export function registerFindReferencesTool(server: McpServer): void {
 	server.tool(
 		"find_references_by_tsmorph",
-		`[Uses ts-morph] Finds the definition and all references to a symbol at a given position throughout the project.
+		`[ts-morph] Locate the definition AND every reference of a symbol at a given position, project-wide. Read-only.
 
-Analyzes the project based on \`tsconfig.json\` to locate the definition and all usages of the symbol (function, variable, class, etc.) specified by its position.
+## When to use
+- Assessing the blast radius of a planned refactor before changing anything.
+- Answering "who calls this function?" / "where is this type used?" precisely.
+- Prefer this over \`grep\` for identifier lookups: grep matches unrelated same-name tokens (different scopes, comments, strings), while this tool uses the type checker to return only true references.
 
-## Usage
+## When NOT to use
+- You just want a free-text search (comments, strings, doc files) -> use \`grep\`.
+- You already plan to rename -> skip straight to \`rename_symbol_by_tsmorph\` (it computes the same set internally and supports \`dryRun\`).
 
-Use this tool before refactoring to understand the impact of changing a specific symbol. It helps identify where a function is called, where a variable is used, etc.
-
-1.  Specify the **absolute path** to the project's \`tsconfig.json\`.
-2.  Specify the **absolute path** to the file containing the symbol you want to investigate.
-3.  Specify the exact **position** (line and column) of the symbol within the file.
-
-## Parameters
-
-- tsconfigPath (string, required): Absolute path to the project's root \`tsconfig.json\` file. Essential for ts-morph to parse the project. **Must be an absolute path.**
-- targetFilePath (string, required): The absolute path to the file containing the symbol to find references for. **Must be an absolute path.**
-- position (object, required): The exact position of the symbol to find references for.
-  - line (number, required): 1-based line number.
-  - column (number, required): 1-based column number.
+## Critical constraints
+- \`position\` must land on the symbol identifier itself (1-based line/column, as shown by editors). A position on whitespace or another token will fail to resolve.
+- All paths (\`tsconfigPath\`, \`targetFilePath\`) MUST be absolute.
 
 ## Result
-
-- On success: Returns a message containing the definition location (if found) and a list of reference locations (file path, line number, column number, and line text).
-- On failure: Returns a message indicating the error.`,
+Returns the definition (file path, line, column, source line) when found, followed by a numbered list of references with the same fields.`,
 		{
 			tsconfigPath: z
 				.string()

--- a/src/mcp/tools/register-move-symbol-to-file-tool.ts
+++ b/src/mcp/tools/register-move-symbol-to-file-tool.ts
@@ -68,40 +68,33 @@ type MoveSymbolArgs = z.infer<typeof moveSymbolSchema>;
 export function registerMoveSymbolToFileTool(server: McpServer): void {
 	server.tool(
 		"move_symbol_to_file_by_tsmorph",
-		`[Uses ts-morph] Moves a specified symbol (function, variable, class, etc.) and its internal-only dependencies to a new file, automatically updating all references across the project. Aids refactoring tasks like file splitting and improving modularity.
+		`[ts-morph] Move one top-level symbol (function, variable, class, interface, type, enum) from one file to another, carrying its internal-only dependencies and rewriting all imports/exports across the project.
 
-Analyzes the AST (Abstract Syntax Tree) to identify usages of the symbol and corrects import/export paths based on the new file location. It also handles moving necessary internal dependencies (those used only by the symbol being moved).
+## When to use
+- Splitting a large file: move related symbols to a new file one by one.
+- Relocating a helper from a generic \`utils.ts\` to a feature-specific module.
+- Prefer this over manual cut-and-paste + import fixing. Manual moves frequently miss re-exports, leave stale imports, or fail to add the new export -- this tool handles all of that via the type checker.
 
-## Usage
+## When NOT to use
+- Renaming the file (without moving a single symbol out of it) -> \`rename_filesystem_entry_by_tsmorph\`.
+- Renaming a symbol in place -> \`rename_symbol_by_tsmorph\`.
+- The symbol you want to move is a \`export default\` -> NOT SUPPORTED, refactor it to a named export first.
 
-Use this tool for various code reorganization tasks:
+## Critical constraints
+- ONE top-level symbol per call. To move N symbols, invoke the tool N times.
+- Default exports CANNOT be moved. Convert them to named exports beforehand.
+- If multiple top-level declarations share the same name (e.g., function + namespace), pass \`declarationKindString\` (e.g., \`"FunctionDeclaration"\`, \`"VariableStatement"\`) to disambiguate.
+- Internal dependency rules:
+  - Dependencies used ONLY by the moved symbol travel with it.
+  - Dependencies also used by other symbols in the source file stay put, gain \`export\` if missing, and are imported back into the destination file.
+- All paths (\`tsconfigPath\`, \`originalFilePath\`, \`targetFilePath\`) MUST be absolute.
+- \`targetFilePath\` may point to a non-existent file; it will be created.
 
-1.  **Moving a specific function/class/variable:** Relocate a specific piece of logic to a more appropriate file (e.g., moving a helper function from a general \`utils.ts\` to a feature-specific \`feature-utils.ts\`). **This tool moves the specified symbol and its internal-only dependencies.**
-2.  **Extracting or Moving related logic (File Splitting/Reorganization):** To split a large file or reorganize logic, move related functions, classes, types, or variables to a **different file (new or existing)** one by one using this tool. **You will need to run this tool multiple times, once for each top-level symbol you want to move.**
-3.  **Improving modularity:** Group related functionalities together by moving multiple symbols (functions, types, etc.) into separate, more focused files. **Run this tool for each symbol you wish to relocate.**
-
-ts-morph parses the project based on \`tsconfig.json\` to resolve references and perform the move safely, updating imports/exports automatically.
-
-## Parameters
-
-- tsconfigPath (string, required): Absolute path to the project\'s root \`tsconfig.json\`
-- originalFilePath (string, required): Absolute path to the file currently containing the symbol to move.
-- targetFilePath (string, required): Absolute path to the destination file. Can be an existing file; if the path does not exist, a new file will be created.
-- symbolToMove (string, required): The name of the **single top-level symbol** you want to move in this execution.
-- declarationKindString (string, optional): The kind of the declaration (e.g., \'VariableStatement\', \'FunctionDeclaration\'). Recommended to resolve ambiguity if multiple symbols share the same name.
-- dryRun (boolean, optional): If true, only show intended changes without modifying files. Defaults to false.
+## Tips
+- Run with \`dryRun: true\` first when the source file has many co-dependencies to confirm what gets pulled along.
 
 ## Result
-
-- On success: Returns a message confirming the move and reference updates, including a list of modified files (or files that would be modified if dryRun is true).
-- On failure: Returns an error message (e.g., symbol not found, default export, AST errors).
-
-## Remarks
-
-- **Moves one top-level symbol per execution:** This tool is designed to move a single specified top-level symbol (and its internal-only dependencies) in each run. To move multiple related top-level symbols (e.g., several functions and types for file splitting), you need to invoke this tool multiple times, once for each symbol.
-- **Default exports cannot be moved.**
-- **Internal dependency handling:** Dependencies (functions, variables, types, etc.) used *only* by the moved symbol within the original file are moved along with it. Dependencies that are also used by other symbols remaining in the original file will stay, might gain an \`export\` keyword if they didn't have one, and will be imported by the new file where the symbol was moved. Symbols in the original file that are *not* dependencies of the moved symbol will remain untouched unless explicitly moved in a separate execution of this tool.
-- **Performance:** Moving symbols with many references in large projects might take time.`,
+Returns the list of modified (or to-be-modified, in dryRun) file paths, plus status and processing time.`,
 		moveSymbolSchema.extend({
 			symbolToMove: z
 				.string()

--- a/src/mcp/tools/register-remove-path-alias-tool.ts
+++ b/src/mcp/tools/register-remove-path-alias-tool.ts
@@ -7,28 +7,27 @@ import { performance } from "node:perf_hooks";
 export function registerRemovePathAliasTool(server: McpServer): void {
 	server.tool(
 		"remove_path_alias_by_tsmorph",
-		`[Uses ts-morph] Replaces path aliases (e.g., '@/') with relative paths in import/export statements within the specified target path.
+		`[ts-morph] Convert path-alias imports/exports (e.g., \`@/components/Button\`) to relative paths (\`../../components/Button\`) within a target file or directory.
 
-Analyzes the project based on \`tsconfig.json\` to resolve aliases and calculate relative paths.
+## When to use
+- Standardizing on relative paths for a subset of the codebase.
+- Preparing for a large \`rename_filesystem_entry_by_tsmorph\` run when you want to control alias rewriting explicitly (note: \`rename_filesystem_entry_by_tsmorph\` already rewrites aliases to relative paths automatically; run this tool first only if you want the conversion to be a separate, reviewable commit).
+- Prefer this over manual find/replace -- relative path computation is error-prone across nested directories.
 
-## Usage
+## When NOT to use
+- The project has no \`paths\` mapping in \`tsconfig.json\` (this tool has nothing to do).
+- You want to ADD aliases or change one alias to another (not supported).
 
-Use this tool to convert alias paths like \`import Button from '@/components/Button'\` to relative paths like \`import Button from '../../components/Button'\`. This can be useful for improving portability or adhering to specific project conventions.
+## Critical constraints
+- Aliases are read from the \`paths\` option of the project's \`tsconfig.json\`. Only those aliases are resolved.
+- \`targetPath\` may be a single file OR a directory. Directory targets process every \`.ts\`/\`.tsx\` file under it.
+- All paths (\`tsconfigPath\`, \`targetPath\`) MUST be absolute.
 
-1.  Specify the **absolute path** to the project\`tsconfig.json\`.
-2.  Specify the **absolute path** to the target file or directory where path aliases should be removed.
-3.  Optionally, run with \`dryRun: true\` to preview the changes without modifying files.
-
-## Parameters
-
-- tsconfigPath (string, required): Absolute path to the project\`tsconfig.json\` file. **Must be an absolute path.**
-- targetPath (string, required): The absolute path to the file or directory to process. **Must be an absolute path.**
-- dryRun (boolean, optional): If true, only show intended changes without modifying files. Defaults to false.
+## Tips
+- Run with \`dryRun: true\` first when applying to a directory, to confirm the scope.
 
 ## Result
-
-- On success: Returns a message containing the list of file paths modified (or scheduled to be modified if dryRun).
-- On failure: Returns a message indicating the error.`,
+Returns the list of modified (or to-be-modified, in dryRun) file paths, plus status and processing time.`,
 		{
 			tsconfigPath: z
 				.string()

--- a/src/mcp/tools/register-rename-file-system-entry-tool.ts
+++ b/src/mcp/tools/register-rename-file-system-entry-tool.ts
@@ -47,43 +47,30 @@ type RenameArgs = z.infer<typeof renameSchema>;
 export function registerRenameFileSystemEntryTool(server: McpServer): void {
 	server.tool(
 		"rename_filesystem_entry_by_tsmorph",
-		`[Uses ts-morph] Renames **one or more** TypeScript/JavaScript files **and/or folders** and updates all import/export paths referencing them throughout the project.
+		`[ts-morph] Rename or move one or more TypeScript/JavaScript files and/or folders, and automatically rewrite every import/export path that references them.
 
-Analyzes the project based on \`tsconfig.json\` to find all references to the items being renamed and automatically corrects their paths. **Handles various path types, including relative paths, path aliases (e.g., @/), and imports referencing a directory\'s index.ts (\`from \'.\'\` or \`from \'..\'\`).** Checks for conflicts before applying changes.
+## When to use
+- Renaming or moving any .ts/.tsx/.js/.jsx file or directory (single or batch).
+- Prefer this over \`mv\` + manual import fixing. This tool resolves references via the type checker, so it handles relative paths, path aliases (\`@/\`), and barrel imports (\`from '.'\`, \`from '..'\`) that grep cannot reliably find.
+- Use batch mode (multiple entries in \`renames\`) when reorganizing several files at once -- a single AST pass is much faster than running the tool repeatedly.
 
-## Usage
+## When NOT to use
+- Renaming a symbol inside a file -> \`rename_symbol_by_tsmorph\`.
+- Moving a single symbol (not the whole file) to another file -> \`move_symbol_to_file_by_tsmorph\`.
 
-Use this tool when you want to rename/move multiple files or folders simultaneously (e.g., renaming \`util.ts\` to \`helper.ts\` and moving \`src/data\` to \`src/coreData\` in one operation) and need all the \`import\`/\`export\` statements referencing them to be updated automatically.
+## Critical constraints
+- Path aliases in updated imports are REWRITTEN AS RELATIVE PATHS (e.g., \`@/foo\` -> \`../foo\`). If you want to keep aliases, run \`remove_path_alias_by_tsmorph\` separately beforehand, or accept the conversion.
+- Barrel imports like \`import X from '../components'\` are rewritten to point at the resolved index file (e.g., \`'../components/index.tsx'\`).
+- Default exports declared via a bare identifier (\`export default Foo;\`) may not be updated correctly. Default function/class declarations (\`export default function foo() {}\`) are handled.
+- All paths (\`tsconfigPath\`, \`oldPath\`, \`newPath\`) MUST be absolute.
+- The tool refuses to run on path conflicts (target already exists, duplicate destinations).
 
-1.  Specify the path to the project's \`tsconfig.json\` file. **Must be an absolute path.**
-2.  Provide an array of rename operations. Each object in the array must contain:
-    - \`oldPath\`: The current **absolute path** of the file or folder to rename.
-    - \`newPath\`: The new desired **absolute path** for the file or folder.
-3.  It\'s recommended to first run with \`dryRun: true\` to check which files will be affected.
-4.  If the preview looks correct, run with \`dryRun: false\` (or omit it) to actually save the changes to the file system.
-
-## Parameters
-
-- tsconfigPath (string, required): Absolute path to the project's root \`tsconfig.json\` file. **Must be an absolute path.**
-- renames (array of objects, required): An array where each object specifies a rename operation with:
-    - oldPath (string, required): The current absolute path of the file or folder. **Must be an absolute path.**
-    - newPath (string, required): The new desired absolute path for the file or folder. **Must be an absolute path.**
-- dryRun (boolean, optional): If set to true, prevents making and saving file changes, returning only the list of files that would be affected. Defaults to false.
-- timeoutSeconds (number, optional): Maximum time in seconds allowed for the operation before it times out. Defaults to 120 seconds.
+## Tips
+- Run with \`dryRun: true\` first for any non-trivial rename to inspect the affected file list.
+- \`timeoutSeconds\` defaults to 120; raise it for very large projects or huge batch renames.
 
 ## Result
-
-- On success: Returns a message listing the file paths modified or scheduled to be modified.
-- On failure: Returns a message indicating the error (e.g., path conflict, file not found, timeout).
-
-## Remarks
-- **Symbol-based Reference Finding:** This tool now primarily uses symbol analysis (identifying exported functions, classes, variables, etc.) to find references across the project, rather than solely relying on path matching.
-- **Path Alias Handling:** Path aliases (e.g., \`@/\`) in import/export statements *are* updated, but they will be **converted to relative paths**. If preserving path aliases is crucial, consider using the \`remove_path_alias_by_tsmorph\` tool *before* renaming to convert them to relative paths preemptively.
-- **Index File Imports:** Imports referencing a directory's \`index.ts\` or \`index.tsx\` (e.g., \`import Component from '../components'\`) will be updated to reference the specific index file directly (e.g., \`import Component from '../components/index.tsx'\`).
-- **Known Limitation (Default Exports):** Currently, this tool may not correctly update references for default exports declared using an identifier (e.g., \`export default MyIdentifier;\`). Default exports using function or class declarations (e.g., \`export default function myFunction() {}\`) are generally handled.
-- **Performance:** Renaming numerous files/folders or operating in a very large project can take significant time due to the detailed symbol analysis and reference updates.
-- **Conflicts:** The tool checks for conflicts (e.g., renaming to an existing path, duplicate targets) before applying changes.
-- **Timeout:** Operations exceeding the specified \`timeoutSeconds\` will be canceled.`,
+Returns the list of modified (or to-be-modified, in dryRun) file paths, plus status and processing time. On timeout the operation is cancelled and an error is returned.`,
 		renameSchema.shape,
 		async (args: RenameArgs) => {
 			const startTime = performance.now();

--- a/src/mcp/tools/register-rename-symbol-tool.ts
+++ b/src/mcp/tools/register-rename-symbol-tool.ts
@@ -6,54 +6,28 @@ import { performance } from "node:perf_hooks";
 export function registerRenameSymbolTool(server: McpServer): void {
 	server.tool(
 		"rename_symbol_by_tsmorph",
-		// Note for developers:
-		// The following English description is primarily intended for the LLM's understanding.
-		// Please refer to the JSDoc comment above for the original Japanese description.
-		`[Uses ts-morph] Renames TypeScript/JavaScript symbols across the project.
+		`[ts-morph] Type-aware rename of a TypeScript/JavaScript symbol (function, variable, class, type, interface, enum, etc.) across the entire project.
 
-Analyzes the AST (Abstract Syntax Tree) to track and update references 
-throughout the project, not just the definition site.
-Useful for cross-file refactoring tasks during Vibe Coding.
+## When to use
+- Renaming any symbol that may be imported, re-exported, or referenced in other files.
+- Prefer this over manual Edit + grep / sed. Identifier-based search misses re-exports, JSX attribute usage, and matches unrelated same-name tokens. This tool resolves references via the type checker, so it is both safer and faster.
+- Even for a "local-only" symbol, this tool is the correct default: it costs nothing extra and guarantees no missed reference.
 
-## Usage
+## When NOT to use
+- Renaming a file or folder (and updating imports to it) -> use \`rename_filesystem_entry_by_tsmorph\`.
+- Moving a symbol to a different file -> use \`move_symbol_to_file_by_tsmorph\`.
+- Just looking up where a symbol is used (no rename) -> use \`find_references_by_tsmorph\`.
 
-Use this tool, for example, when you change a function name defined in one file 
-and want to reflect that change in other files that import and use it.
-ts-morph parses the project based on \`tsconfig.json\` to resolve symbol references 
-and perform the rename.
+## Critical constraints
+- \`position\` must point at the symbol's identifier (1-based line/column, as shown by editors). If the position lands on whitespace or a different token, the rename fails.
+- \`symbolName\` must match the identifier text at that position; it is used as a sanity check.
+- All paths (\`tsconfigPath\`, \`targetFilePath\`) MUST be absolute.
 
-1.  Specify the exact location (file path, line, column) of the symbol 
-    (function name, variable name, class name, etc.) you want to rename. 
-    This is necessary for ts-morph to identify the target Identifier node in the AST.
-2.  Specify the current symbol name and the new symbol name.
-3.  It\'s recommended to first run with \`dryRun: true\` to check which files 
-    ts-morph will modify.
-4.  If the preview looks correct, run with \`dryRun: false\` (or omit it) 
-    to actually save the changes to the file system.
-
-## Parameters
-
-- tsconfigPath (string, required): Path to the project\'s root \`tsconfig.json\` file. 
-  Essential for ts-morph to correctly parse the project structure and file references. **Must be an absolute path (relative paths can be misinterpreted).**
-- targetFilePath (string, required): Path to the file where the symbol to be renamed 
-  is defined (or first appears). **Must be an absolute path (relative paths can be misinterpreted).**
-- position (object, required): The exact position on the symbol to be renamed. 
-  Serves as the starting point for ts-morph to locate the AST node.
-  - line (number, required): 1-based line number, typically obtained from an editor.
-  - column (number, required): 1-based column number (position of the first character 
-    of the symbol name), typically obtained from an editor.
-- symbolName (string, required): The current name of the symbol before renaming. 
-  Used to verify against the node name found at the specified position.
-- newName (string, required): The new name for the symbol after renaming.
-- dryRun (boolean, optional): If set to true, prevents ts-morph from making and saving 
-  file changes, returning only the list of files that would be affected. 
-  Useful for verification. Defaults to false.
+## Tips
+- Run with \`dryRun: true\` first when the change spans many files, to preview the affected file list.
 
 ## Result
-
-- On success: Returns a message containing the list of file paths modified 
-  (or scheduled to be modified if dryRun) by the rename.
-- On failure: Returns a message indicating the error.`,
+Returns the list of modified (or to-be-modified, in dryRun) file paths, plus status and processing time.`,
 		{
 			tsconfigPath: z
 				.string()


### PR DESCRIPTION
## Summary
- 5 つの MCP ツール (`rename_symbol`, `rename_filesystem_entry`, `move_symbol_to_file`, `find_references`, `remove_path_alias`) の description を統一テンプレで書き直し
- agent が冒頭 3 行で「使う/使わない」を判断できる形に整理し、ツール間の使い分けを明示
- 重要制約 (default export 非対応・alias→相対パス変換・1 回 1 シンボル 等) を Remarks から **Critical constraints** に引き上げ
- Zod スキーマと重複していた Parameters 詳述を削除し、description 全体を 50–200 行 → 20–30 行に圧縮

## なぜ
旧 description は丁寧だが冗長で、agent が context に積むコストが高かった。また「いつ使うか」が末尾に埋もれており、agent が grep + Edit で済ませてしまいやすかった。今回の再構成で:
1. **積極活用**: 「Prefer this over manual Edit + grep because ...」を全ツールに明記
2. **誤解防止**: 制約を冒頭近くに引き上げ
3. **ナビゲーション**: 「これではなく X を使うべきケース」を相互参照

## 統一テンプレ
\`\`\`
[ts-morph] <1 行サマリ>

## When to use
- <典型ケース>
- Prefer this over <手動手段> because <理由>

## When NOT to use
- <別ツール推奨ケース>

## Critical constraints
- <制約>

## Tips
- <dryRun 推奨タイミング等>

## Result
<戻り値の形>
\`\`\`

## Test plan
- [x] `pnpm check-types` pass
- [x] `pnpm test` (203 passed / 1 既存 skip)
- [x] pre-push hook (format + test) pass
- [ ] 実際に agent から各ツールを呼び出して description の効果を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)