### PR TITLE
fix(release): pnpm pkg delete → npm pkg delete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,10 +115,11 @@ jobs:
           echo "dist/version.js contains the expected line: $expected"
 
       # publish 直前に internal-only な _version_note を除去 (npm registry に
-      # 内部スキルパスを露出させない)。pnpm pkg delete は ./package.json を
-      # in-place で書き換える。
+      # 内部スキルパスを露出させない)。`pnpm pkg` は pnpm v11 時点で未実装
+      # (ERR_PNPM_NOT_IMPLEMENTED) なので npm CLI の `npm pkg` を直接呼ぶ。
+      # package.json を in-place で書き換える。
       - name: Strip internal _version_note before publish
-        run: pnpm pkg delete _version_note
+        run: npm pkg delete _version_note
 
       - name: Publish to npm (pnpm + Trusted Publishing via OIDC)
         # サプライチェーン攻撃対策の観点から publish も pnpm 経由に統一。


### PR DESCRIPTION
## Summary
v1.2.0 のリリースワークフローが \`Strip internal _version_note before publish\` step で **ERR_PNPM_NOT_IMPLEMENTED** により失敗していたため、修正。

## エラー実物
\`\`\`
[ERR_PNPM_NOT_IMPLEMENTED] The \"pkg\" command is not yet implemented in pnpm. Use the npm CLI directly: npm pkg
\`\`\`

pnpm v11 時点で \`pnpm pkg\` は未実装。pnpm 本人が \`npm pkg\` を直接使えと案内する。

## 修正
\`pnpm pkg delete _version_note\` → \`npm pkg delete _version_note\`

\`npm\` は同 workflow の \`Upgrade npm to >= 11.5.1 for trusted publishing\` で既にインストール済みなので追加の install は不要。

## 影響
- **v1.2.0 は npm に publish されていません** (publish step 自体が走らず終了)。npm registry は v1.1.0 のまま。
- tag \`v1.2.0\` は origin に残置 (SKILL.md の fix-forward 方針: tag を消さずに次の patch を打つ)。
- このマージ後、\`v1.2.1\` を打ってリリースを再試行する想定。

## ローカル検証
- \`cp package.json /tmp/bak; npm pkg delete _version_note; <確認>; cp /tmp/bak package.json\` で \`_version_note\` だけが正しく除去されることを確認。
- pre-push hook 通過 (format + test pass)。

## 教訓 / 残課題
- ローカル simulation で \`pnpm pkg delete\` をテストしていなかった (CLI 差異を catch できなかった)。release.yml の bake-like ステップは可能な限りローカル再現可能な node script に寄せる方針 (release-version.mjs と同様) が安全。今回の \`npm pkg delete\` は単発なので script 化は見送り。

🤖 Generated with [Claude Code](https://claude.com/claude-code)