### PR TITLE
chore(ci): GitHub Actions のバージョンを Node.js 24 対応版に bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # ── 全 Action は commit SHA でピン留め (タグ retag によるサプライチェーン攻撃を防ぐ)。
+      # release.yml と同じバージョン (v4 系は Node.js 20 ベースで 2026-09-16 に runner から
+      # 削除予定のため、Node.js 24 ベースの v6 系に上げている)。
       - name: Checkout code
-        uses: actions/checkout@v4
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        # pnpm/action-setup@v6.0.8 — version は package.json の packageManager から取る
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        # actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'


### PR DESCRIPTION
## Summary
\`ci.yml\` の各 step が v4 系 Action (Node.js 20 ベース) を使っており、GitHub Actions runner から **2026-09-16 に削除予定** で deprecation warning が出ていた。\`release.yml\` は既に commit SHA pin の最新版 (v6 系 = Node.js 24 ベース) に揃えてあるので、\`ci.yml\` も同じ pin に統一。

## 警告実物
\`\`\`
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected:
  actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
Node.js 20 will be removed from the runner on September 16th, 2026.
\`\`\`

## 変更
| Action | Before | After (commit SHA pin) |
|---|---|---|
| actions/checkout | \`v4\` | \`de0fac2e4500dabe0009e67214ff5f5447ce83dd\` (v6.0.2) |
| pnpm/action-setup | \`v4\` | \`0e279bb959325dab635dd2c09392533439d90093\` (v6.0.8) |
| actions/setup-node | \`v4\` | \`48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e\` (v6.4.0) |

SHA は \`release.yml\` で既に v1.2.1 のリリースに成功している実績ある pin をそのまま流用。

## なぜ commit SHA pin
タグ名は再付与可能 (e.g. \`v4\` を後から悪意のあるコミットに付け直せる) ため、サプライチェーン攻撃対策として全 Action を commit SHA で固定する方針を \`release.yml\` 以降採用している。今回 \`ci.yml\` もそれに合わせた。

## 差分メモ
- \`setup-node\` の \`node-version-file: 'package.json'\` は維持 (volta の Node 22.14.0 を使う)。
- \`release.yml\` だけは Trusted Publishing 要件で \`node-version: '22'\` を明示 override しているのが唯一の差分。

## Test plan
- [x] pre-push hook (format + test) pass
- [ ] このブランチで CI が green になるか確認 (PR 起動した CI 自身で検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)