### PR TITLE
refactor(test): 共通ヘルパー化・冗長削減・カバレッジ改善

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build_and_test:

--- a/src/ts-morph/_test-utils/create-in-memory-project.ts
+++ b/src/ts-morph/_test-utils/create-in-memory-project.ts
@@ -1,0 +1,37 @@
+import {
+	IndentationText,
+	type ManipulationSettings,
+	Project,
+	QuoteKind,
+} from "ts-morph";
+
+type Options = {
+	pathAliases?: Record<string, string[]>;
+	manipulationSettings?: Partial<ManipulationSettings>;
+};
+
+const DEFAULT_PATH_ALIASES: Record<string, string[]> = {
+	"@/*": ["src/*"],
+};
+
+export function createInMemoryProject(options: Options = {}): Project {
+	return new Project({
+		useInMemoryFileSystem: true,
+		compilerOptions: {
+			baseUrl: ".",
+			paths: options.pathAliases ?? DEFAULT_PATH_ALIASES,
+			esModuleInterop: true,
+			allowJs: true,
+		},
+		manipulationSettings: options.manipulationSettings,
+	});
+}
+
+export function createInMemoryProjectWithDoubleQuotes(): Project {
+	return createInMemoryProject({
+		manipulationSettings: {
+			indentationText: IndentationText.TwoSpaces,
+			quoteKind: QuoteKind.Double,
+		},
+	});
+}

--- a/src/ts-morph/_test-utils/expect-file-moved.ts
+++ b/src/ts-morph/_test-utils/expect-file-moved.ts
@@ -1,0 +1,14 @@
+import type { Project } from "ts-morph";
+import { expect } from "vitest";
+
+export function expectFileMoved(
+	project: Project,
+	from: string,
+	to: string,
+): void {
+	expect(
+		project.getSourceFile(from),
+		`expected '${from}' to be removed`,
+	).toBeUndefined();
+	expect(project.getSourceFile(to), `expected '${to}' to exist`).toBeDefined();
+}

--- a/src/ts-morph/_test-utils/get-file-text.ts
+++ b/src/ts-morph/_test-utils/get-file-text.ts
@@ -1,0 +1,9 @@
+import type { Project } from "ts-morph";
+
+export function getFileText(project: Project, path: string): string {
+	const sourceFile = project.getSourceFile(path);
+	if (!sourceFile) {
+		throw new Error(`Test setup failed: source file '${path}' not found`);
+	}
+	return sourceFile.getFullText();
+}

--- a/src/ts-morph/_test-utils/get-statement.ts
+++ b/src/ts-morph/_test-utils/get-statement.ts
@@ -1,0 +1,16 @@
+import type { SourceFile, Statement, SyntaxKind } from "ts-morph";
+import { findTopLevelDeclarationByName } from "../move-symbol-to-file/find-declaration";
+
+export function getStatement<T extends Statement>(
+	sourceFile: SourceFile,
+	name: string,
+	kind: SyntaxKind,
+): T {
+	const statement = findTopLevelDeclarationByName(sourceFile, name, kind);
+	if (!statement) {
+		throw new Error(
+			`Test setup failed: top-level declaration '${name}' (kind=${kind}) not found`,
+		);
+	}
+	return statement as T;
+}

--- a/src/ts-morph/_test-utils/get-statement.ts
+++ b/src/ts-morph/_test-utils/get-statement.ts
@@ -1,16 +1,16 @@
-import type { SourceFile, Statement, SyntaxKind } from "ts-morph";
+import type { KindToNodeMappings, SourceFile, SyntaxKind } from "ts-morph";
 import { findTopLevelDeclarationByName } from "../move-symbol-to-file/find-declaration";
 
-export function getStatement<T extends Statement>(
+export function getStatement<K extends SyntaxKind>(
 	sourceFile: SourceFile,
 	name: string,
-	kind: SyntaxKind,
-): T {
+	kind: K,
+): KindToNodeMappings[K] {
 	const statement = findTopLevelDeclarationByName(sourceFile, name, kind);
 	if (!statement) {
 		throw new Error(
 			`Test setup failed: top-level declaration '${name}' (kind=${kind}) not found`,
 		);
 	}
-	return statement as T;
+	return statement as KindToNodeMappings[K];
 }

--- a/src/ts-morph/_utils/ts-morph-project.test.ts
+++ b/src/ts-morph/_utils/ts-morph-project.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import {
+	getTsConfigAliasKeys,
+	getTsConfigBaseUrl,
+	getTsConfigPaths,
+} from "./ts-morph-project";
+
+vi.mock("../../utils/logger");
+
+describe("getTsConfigPaths", () => {
+	it("paths が設定されていない場合は undefined を返す", () => {
+		const project = createInMemoryProject({ pathAliases: {} });
+		project.compilerOptions.set({ baseUrl: ".", paths: undefined });
+		expect(getTsConfigPaths(project)).toBeUndefined();
+	});
+
+	it("正常な paths を返す", () => {
+		const project = createInMemoryProject({
+			pathAliases: { "@/*": ["src/*"], "@lib/*": ["lib/*"] },
+		});
+		expect(getTsConfigPaths(project)).toEqual({
+			"@/*": ["src/*"],
+			"@lib/*": ["lib/*"],
+		});
+	});
+
+	it("paths の値が文字列配列でないエントリはスキップされる", () => {
+		const project = createInMemoryProject();
+		project.compilerOptions.set({
+			baseUrl: ".",
+			paths: {
+				"@/*": ["src/*"],
+				// @ts-expect-error 不正値の動作を検証
+				"@bad": "not-an-array",
+				// @ts-expect-error 不正値の動作を検証
+				"@mixed/*": [123, "lib/*"],
+			},
+		});
+
+		expect(getTsConfigPaths(project)).toEqual({ "@/*": ["src/*"] });
+	});
+
+	it("paths がオブジェクト以外の場合は undefined を返す", () => {
+		const project = createInMemoryProject();
+		// @ts-expect-error 不正値の動作を検証
+		project.compilerOptions.set({ baseUrl: ".", paths: "invalid" });
+		expect(getTsConfigPaths(project)).toBeUndefined();
+	});
+});
+
+describe("getTsConfigAliasKeys", () => {
+	it("paths のキー一覧を返す", () => {
+		const project = createInMemoryProject({
+			pathAliases: { "@/*": ["src/*"], "@lib/*": ["lib/*"] },
+		});
+		expect(getTsConfigAliasKeys(project).sort()).toEqual(["@/*", "@lib/*"]);
+	});
+
+	it("paths が無ければ空配列を返す", () => {
+		const project = createInMemoryProject({ pathAliases: {} });
+		project.compilerOptions.set({ baseUrl: ".", paths: undefined });
+		expect(getTsConfigAliasKeys(project)).toEqual([]);
+	});
+});
+
+describe("getTsConfigBaseUrl", () => {
+	it("baseUrl を返す", () => {
+		const project = createInMemoryProject();
+		expect(getTsConfigBaseUrl(project)).toBe(".");
+	});
+
+	it("baseUrl が設定されていない場合は undefined を返す", () => {
+		const project = createInMemoryProject();
+		project.compilerOptions.set({ baseUrl: undefined });
+		expect(getTsConfigBaseUrl(project)).toBeUndefined();
+	});
+});

--- a/src/ts-morph/move-symbol-to-file/classify-dependencies.test.ts
+++ b/src/ts-morph/move-symbol-to-file/classify-dependencies.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { type FunctionDeclaration, SyntaxKind } from "ts-morph";
+import { type Statement, SyntaxKind } from "ts-morph";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { getStatement } from "../_test-utils/get-statement";
 import { getInternalDependencies } from "./internal-dependencies";
@@ -17,7 +17,7 @@ const setupTest = (
 		sourceFile,
 		targetSymbolName,
 		targetKind,
-	);
+	) as Statement;
 	const internalDependencies = getInternalDependencies(targetDeclaration);
 	return { sourceFile, targetDeclaration, internalDependencies };
 };
@@ -33,7 +33,7 @@ describe("classifyDependencies", () => {
 			SyntaxKind.VariableStatement,
 		);
 
-		const helperDep = getStatement<FunctionDeclaration>(
+		const helperDep = getStatement(
 			sourceFile,
 			"helper",
 			SyntaxKind.FunctionDeclaration,
@@ -56,7 +56,7 @@ describe("classifyDependencies", () => {
 			SyntaxKind.VariableStatement,
 		);
 
-		const sharedHelperDep = getStatement<FunctionDeclaration>(
+		const sharedHelperDep = getStatement(
 			sourceFile,
 			"sharedHelper",
 			SyntaxKind.FunctionDeclaration,
@@ -84,7 +84,7 @@ describe("classifyDependencies", () => {
 			SyntaxKind.VariableStatement,
 		);
 
-		const utilDep = getStatement<FunctionDeclaration>(
+		const utilDep = getStatement(
 			sourceFile,
 			"util",
 			SyntaxKind.FunctionDeclaration,
@@ -129,17 +129,17 @@ describe("classifyDependencies", () => {
 			SyntaxKind.VariableStatement,
 		);
 
-		const privateHelperDep = getStatement<FunctionDeclaration>(
+		const privateHelperDep = getStatement(
 			sourceFile,
 			"privateHelper",
 			SyntaxKind.FunctionDeclaration,
 		);
-		const sharedExportedDep = getStatement<FunctionDeclaration>(
+		const sharedExportedDep = getStatement(
 			sourceFile,
 			"sharedExportedHelper",
 			SyntaxKind.FunctionDeclaration,
 		);
-		const sharedNonExportedDep = getStatement<FunctionDeclaration>(
+		const sharedNonExportedDep = getStatement(
 			sourceFile,
 			"sharedNonExportedUtil",
 			SyntaxKind.FunctionDeclaration,

--- a/src/ts-morph/move-symbol-to-file/classify-dependencies.test.ts
+++ b/src/ts-morph/move-symbol-to-file/classify-dependencies.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { Project, SyntaxKind } from "ts-morph";
+import { SyntaxKind } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { findTopLevelDeclarationByName } from "./find-declaration";
 import { getInternalDependencies } from "./internal-dependencies";
 import type { DependencyClassification } from "../types";
 import { classifyDependencies } from "./classify-dependencies";
 
-// テスト用ヘルパー: コードからプロジェクトと主要要素を取得
 const setupTest = (
 	code: string,
 	targetSymbolName: string,
 	targetKind: SyntaxKind,
 ) => {
-	const project = new Project({ useInMemoryFileSystem: true });
+	const project = createInMemoryProject();
 	const sourceFile = project.createSourceFile("/src/module.ts", code);
 	const targetDeclaration = findTopLevelDeclarationByName(
 		sourceFile,

--- a/src/ts-morph/move-symbol-to-file/classify-dependencies.test.ts
+++ b/src/ts-morph/move-symbol-to-file/classify-dependencies.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { SyntaxKind } from "ts-morph";
+import { type FunctionDeclaration, SyntaxKind } from "ts-morph";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
-import { findTopLevelDeclarationByName } from "./find-declaration";
+import { getStatement } from "../_test-utils/get-statement";
 import { getInternalDependencies } from "./internal-dependencies";
 import type { DependencyClassification } from "../types";
 import { classifyDependencies } from "./classify-dependencies";
@@ -13,74 +13,58 @@ const setupTest = (
 ) => {
 	const project = createInMemoryProject();
 	const sourceFile = project.createSourceFile("/src/module.ts", code);
-	const targetDeclaration = findTopLevelDeclarationByName(
+	const targetDeclaration = getStatement(
 		sourceFile,
 		targetSymbolName,
 		targetKind,
 	);
-	const internalDependencies = targetDeclaration
-		? getInternalDependencies(targetDeclaration)
-		: [];
-
-	if (!targetDeclaration) {
-		throw new Error(`Target symbol '${targetSymbolName}' not found.`);
-	}
-
-	return { project, sourceFile, targetDeclaration, internalDependencies };
+	const internalDependencies = getInternalDependencies(targetDeclaration);
+	return { sourceFile, targetDeclaration, internalDependencies };
 };
 
 describe("classifyDependencies", () => {
 	it("exportされておらず、移動対象からのみ参照される依存は moveToNewFile に分類される", () => {
-		const code = `
-			function helper() { return 1; }
-			export const main = () => helper();
-		`;
-		const { targetDeclaration, internalDependencies } = setupTest(
-			code,
+		const { sourceFile, targetDeclaration, internalDependencies } = setupTest(
+			`
+				function helper() { return 1; }
+				export const main = () => helper();
+			`,
 			"main",
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(internalDependencies.length).toBe(1);
-		const helperDep = internalDependencies[0];
-		expect(helperDep).toBeDefined();
-		if (!helperDep) return;
-		expect(helperDep.getKind()).toBe(SyntaxKind.FunctionDeclaration);
-
-		const classified = classifyDependencies(
-			targetDeclaration,
-			internalDependencies,
+		const helperDep = getStatement<FunctionDeclaration>(
+			sourceFile,
+			"helper",
+			SyntaxKind.FunctionDeclaration,
 		);
 
-		expect(classified).toEqual<DependencyClassification[]>([
+		expect(
+			classifyDependencies(targetDeclaration, internalDependencies),
+		).toEqual<DependencyClassification[]>([
 			{ type: "moveToNewFile", statement: helperDep },
 		]);
 	});
 
 	it("exportされており、移動対象から参照される依存は importFromOriginal に分類される", () => {
-		const code = `
-			export function sharedHelper() { return 2; } // export されている
-			export const main = () => sharedHelper();
-			// 他の参照があってもなくても export されていれば B' 扱い
-		`;
-		const { targetDeclaration, internalDependencies } = setupTest(
-			code,
+		const { sourceFile, targetDeclaration, internalDependencies } = setupTest(
+			`
+				export function sharedHelper() { return 2; }
+				export const main = () => sharedHelper();
+			`,
 			"main",
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(internalDependencies.length).toBe(1);
-		const sharedHelperDep = internalDependencies[0];
-		expect(sharedHelperDep).toBeDefined();
-		if (!sharedHelperDep) return;
-		expect(sharedHelperDep.getKind()).toBe(SyntaxKind.FunctionDeclaration);
-
-		const classified = classifyDependencies(
-			targetDeclaration,
-			internalDependencies,
+		const sharedHelperDep = getStatement<FunctionDeclaration>(
+			sourceFile,
+			"sharedHelper",
+			SyntaxKind.FunctionDeclaration,
 		);
 
-		expect(classified).toEqual<DependencyClassification[]>([
+		expect(
+			classifyDependencies(targetDeclaration, internalDependencies),
+		).toEqual<DependencyClassification[]>([
 			{
 				type: "importFromOriginal",
 				statement: sharedHelperDep,
@@ -90,99 +74,82 @@ describe("classifyDependencies", () => {
 	});
 
 	it("exportされておらず、移動対象以外からも参照される依存は addExport に分類される", () => {
-		const code = `
-			function util() { return 3; } // export されていない
-			export const main = () => util();
-			export const another = () => util();
-		`;
-		const { targetDeclaration, internalDependencies } = setupTest(
-			code,
-			"main", // main を移動対象とする
+		const { sourceFile, targetDeclaration, internalDependencies } = setupTest(
+			`
+				function util() { return 3; }
+				export const main = () => util();
+				export const another = () => util();
+			`,
+			"main",
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(internalDependencies.length).toBe(1);
-		const utilDep = internalDependencies[0];
-		expect(utilDep).toBeDefined();
-		if (!utilDep) return;
-		expect(utilDep.getKind()).toBe(SyntaxKind.FunctionDeclaration);
-
-		const classified = classifyDependencies(
-			targetDeclaration,
-			internalDependencies,
+		const utilDep = getStatement<FunctionDeclaration>(
+			sourceFile,
+			"util",
+			SyntaxKind.FunctionDeclaration,
 		);
 
-		expect(classified).toEqual<DependencyClassification[]>([
+		expect(
+			classifyDependencies(targetDeclaration, internalDependencies),
+		).toEqual<DependencyClassification[]>([
 			{ type: "addExport", statement: utilDep, name: "util" },
 		]);
 	});
 
 	it("内部依存関係がない場合は空配列を返す", () => {
-		const code = "export const main = 123;";
 		const { targetDeclaration, internalDependencies } = setupTest(
-			code,
+			"export const main = 123;",
 			"main",
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(internalDependencies.length).toBe(0);
-
-		const classified = classifyDependencies(
-			targetDeclaration,
-			internalDependencies,
-		);
-
-		expect(classified).toEqual([]);
+		expect(internalDependencies).toHaveLength(0);
+		expect(
+			classifyDependencies(targetDeclaration, internalDependencies),
+		).toEqual([]);
 	});
 
 	it("複数の依存関係が混在する場合、それぞれ正しく分類される", () => {
-		const code = `
-			function privateHelper() { return 'A'; } // Case A: main からのみ参照
-			export function sharedExportedHelper() { return 'B'; } // Case B': export 済み
-			function sharedNonExportedUtil() { return 'C'; } // Case B'': main と another から参照
+		const { sourceFile, targetDeclaration, internalDependencies } = setupTest(
+			`
+				function privateHelper() { return 'A'; }
+				export function sharedExportedHelper() { return 'B'; }
+				function sharedNonExportedUtil() { return 'C'; }
 
-			export const main = () => {
-				return privateHelper() + sharedExportedHelper() + sharedNonExportedUtil();
-			};
+				export const main = () => {
+					return privateHelper() + sharedExportedHelper() + sharedNonExportedUtil();
+				};
 
-			export const another = () => {
-				// sharedExportedHelper も参照
-				return sharedExportedHelper() + sharedNonExportedUtil();
-			};
-		`;
-		const { project, sourceFile, targetDeclaration, internalDependencies } =
-			setupTest(code, "main", SyntaxKind.VariableStatement);
+				export const another = () => {
+					return sharedExportedHelper() + sharedNonExportedUtil();
+				};
+			`,
+			"main",
+			SyntaxKind.VariableStatement,
+		);
 
-		const privateHelperDep = findTopLevelDeclarationByName(
+		const privateHelperDep = getStatement<FunctionDeclaration>(
 			sourceFile,
 			"privateHelper",
 			SyntaxKind.FunctionDeclaration,
 		);
-		const sharedExportedDep = findTopLevelDeclarationByName(
+		const sharedExportedDep = getStatement<FunctionDeclaration>(
 			sourceFile,
 			"sharedExportedHelper",
 			SyntaxKind.FunctionDeclaration,
 		);
-		const sharedNonExportedDep = findTopLevelDeclarationByName(
+		const sharedNonExportedDep = getStatement<FunctionDeclaration>(
 			sourceFile,
 			"sharedNonExportedUtil",
 			SyntaxKind.FunctionDeclaration,
 		);
 
-		expect(internalDependencies.length).toBe(3);
-		expect(privateHelperDep).toBeDefined();
-		expect(sharedExportedDep).toBeDefined();
-		expect(sharedNonExportedDep).toBeDefined();
-		if (!privateHelperDep || !sharedExportedDep || !sharedNonExportedDep)
-			return;
-
 		const classified = classifyDependencies(
 			targetDeclaration,
 			internalDependencies,
 		);
 
-		// 順序は不定なので、内容が一致するか確認
-		expect(classified).toHaveLength(3);
 		expect(classified).toEqual(
 			expect.arrayContaining<DependencyClassification>([
 				{ type: "moveToNewFile", statement: privateHelperDep },
@@ -198,5 +165,6 @@ describe("classifyDependencies", () => {
 				},
 			]),
 		);
+		expect(classified).toHaveLength(3);
 	});
 });

--- a/src/ts-morph/move-symbol-to-file/collect-external-imports.test.ts
+++ b/src/ts-morph/move-symbol-to-file/collect-external-imports.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { SyntaxKind, type Statement } from "ts-morph";
+import { SyntaxKind } from "ts-morph";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
-import { findTopLevelDeclarationByName } from "./find-declaration";
+import { getStatement } from "../_test-utils/get-statement";
 import { collectNeededExternalImports } from "./collect-external-imports";
 
 const setupTest = (
@@ -11,16 +11,10 @@ const setupTest = (
 ) => {
 	const project = createInMemoryProject();
 	const sourceFile = project.createSourceFile("/src/module.ts", code);
-	const targetStatements: Statement[] = [];
-	for (const name of targetSymbolNames) {
-		const stmt = findTopLevelDeclarationByName(sourceFile, name, targetKind);
-		if (stmt) {
-			targetStatements.push(stmt);
-		} else {
-			throw new Error(`Target symbol '${name}' not found.`);
-		}
-	}
-	return { project, sourceFile, targetStatements };
+	const targetStatements = targetSymbolNames.map((name) =>
+		getStatement(sourceFile, name, targetKind),
+	);
+	return { sourceFile, targetStatements };
 };
 
 describe("collectNeededExternalImports", () => {

--- a/src/ts-morph/move-symbol-to-file/collect-external-imports.test.ts
+++ b/src/ts-morph/move-symbol-to-file/collect-external-imports.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { Project, SyntaxKind, type Statement } from "ts-morph";
+import { SyntaxKind, type Statement } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { findTopLevelDeclarationByName } from "./find-declaration";
 import { collectNeededExternalImports } from "./collect-external-imports";
 
-// テスト用ヘルパー
 const setupTest = (
 	code: string,
 	targetSymbolNames: string[],
 	targetKind: SyntaxKind = SyntaxKind.VariableStatement,
 ) => {
-	const project = new Project({ useInMemoryFileSystem: true });
+	const project = createInMemoryProject();
 	const sourceFile = project.createSourceFile("/src/module.ts", code);
 	const targetStatements: Statement[] = [];
 	for (const name of targetSymbolNames) {

--- a/src/ts-morph/move-symbol-to-file/collect-external-imports.test.ts
+++ b/src/ts-morph/move-symbol-to-file/collect-external-imports.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { SyntaxKind } from "ts-morph";
+import { type Statement, SyntaxKind } from "ts-morph";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { getStatement } from "../_test-utils/get-statement";
 import { collectNeededExternalImports } from "./collect-external-imports";
@@ -11,8 +11,8 @@ const setupTest = (
 ) => {
 	const project = createInMemoryProject();
 	const sourceFile = project.createSourceFile("/src/module.ts", code);
-	const targetStatements = targetSymbolNames.map((name) =>
-		getStatement(sourceFile, name, targetKind),
+	const targetStatements: Statement[] = targetSymbolNames.map(
+		(name) => getStatement(sourceFile, name, targetKind) as Statement,
 	);
 	return { sourceFile, targetStatements };
 };

--- a/src/ts-morph/move-symbol-to-file/ensure-exports-in-original-file.test.ts
+++ b/src/ts-morph/move-symbol-to-file/ensure-exports-in-original-file.test.ts
@@ -1,19 +1,14 @@
 import { describe, it, expect, vi } from "vitest";
-import { Project } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import type { DependencyClassification } from "../types";
 import { ensureExportsInOriginalFile } from "./ensure-exports-in-original-file";
 import logger from "../../utils/logger";
 
-// logger.warn のモック
 vi.mock("../../utils/logger");
 
 describe("ensureExportsInOriginalFile", () => {
-	const setupProject = () => {
-		return new Project({ useInMemoryFileSystem: true });
-	};
-
 	it("addExport タイプで未エクスポートの場合、export キーワードを追加する", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const sourceFile = project.createSourceFile(
 			"original.ts",
 			"const dep1 = 1;\nfunction dep2() {}",
@@ -44,7 +39,7 @@ describe("ensureExportsInOriginalFile", () => {
 	});
 
 	it("addExport タイプで既にエクスポート済みの場合、変更しない", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const sourceFile = project.createSourceFile(
 			"original.ts",
 			"export const dep1 = 1;\nexport function dep2() {}",
@@ -75,7 +70,7 @@ describe("ensureExportsInOriginalFile", () => {
 	});
 
 	it("addExport タイプでない依存関係は無視する", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const sourceFile = project.createSourceFile(
 			"original.ts",
 			"const dep1 = 1;",
@@ -98,7 +93,7 @@ describe("ensureExportsInOriginalFile", () => {
 	});
 
 	it("エクスポート不可能なノードに対して警告ログを出力する", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		// エクスポートできないステートメント (例: ラベル付きステートメント)
 		const sourceFile = project.createSourceFile(
 			"original.ts",

--- a/src/ts-morph/move-symbol-to-file/find-declaration.test.ts
+++ b/src/ts-morph/move-symbol-to-file/find-declaration.test.ts
@@ -3,26 +3,17 @@ import {
 	type ClassDeclaration,
 	type FunctionDeclaration,
 	type InterfaceDeclaration,
-	Project,
 	SyntaxKind,
 	type TypeAliasDeclaration,
 	type SourceFile,
 	type VariableStatement,
 	type Statement,
 } from "ts-morph";
-import { findTopLevelDeclarationByName } from "./find-declaration";
-import { getIdentifierFromDeclaration } from "./find-declaration";
-// import { getTopLevelDeclarationsFromFile } from './move-symbol'; // 不要
-
-// --- Test Setup Helper ---
-const setupProject = () => {
-	const project = new Project({
-		useInMemoryFileSystem: true,
-		compilerOptions: { target: 99, module: 99 },
-	});
-	project.createDirectory("/src");
-	return project;
-};
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import {
+	findTopLevelDeclarationByName,
+	getIdentifierFromDeclaration,
+} from "./find-declaration";
 
 // --- Test Data ---
 const commonTestSource = `
@@ -139,12 +130,12 @@ const testCases: TestCase[] = [
 
 describe("findTopLevelDeclarationByName", () => {
 	const setupSourceFile = (content: string): SourceFile => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const filePath = "/src/test-find.ts";
 		return project.createSourceFile(filePath, content);
 	};
 
-	const sourceFile = setupSourceFile(commonTestSource); // 事前に SourceFile を作成
+	const sourceFile = setupSourceFile(commonTestSource);
 
 	it.each<TestCase>(testCases)(
 		"%s (name: %s, kind: %s)",
@@ -194,9 +185,8 @@ describe("findTopLevelDeclarationByName", () => {
 });
 
 describe("getIdentifierFromDeclaration", () => {
-	// Helper to create a project and get the first statement
 	const getFirstStatement = (code: string): Statement | undefined => {
-		const project = new Project({ useInMemoryFileSystem: true });
+		const project = createInMemoryProject();
 		const sourceFile = project.createSourceFile("test.ts", code);
 		return sourceFile.getStatements()[0];
 	};
@@ -264,11 +254,13 @@ describe("getIdentifierFromDeclaration", () => {
 	});
 
 	it("ExportAssignment (識別子) の識別子を返すこと", () => {
-		const code = "const foo = 1;\nexport default foo;";
-		const project = new Project({ useInMemoryFileSystem: true });
-		const sourceFile = project.createSourceFile("test.ts", code);
-		const statement = sourceFile.getStatements()[1]; // ExportAssignment を取得
-		const identifier = getIdentifierFromDeclaration(statement);
+		const project = createInMemoryProject();
+		const sourceFile = project.createSourceFile(
+			"test.ts",
+			"const foo = 1;\nexport default foo;",
+		);
+		const exportAssignment = sourceFile.getStatements()[1];
+		const identifier = getIdentifierFromDeclaration(exportAssignment);
 		expect(identifier?.getText()).toBe("foo");
 	});
 

--- a/src/ts-morph/move-symbol-to-file/find-declaration.test.ts
+++ b/src/ts-morph/move-symbol-to-file/find-declaration.test.ts
@@ -191,93 +191,91 @@ describe("getIdentifierFromDeclaration", () => {
 		return sourceFile.getStatements()[0];
 	};
 
-	it("FunctionDeclaration の識別子を返すこと", () => {
-		const statement = getFirstStatement("function myFunction() {}");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier?.getText()).toBe("myFunction");
+	type FirstStatementCase = {
+		description: string;
+		code: string;
+		expected: string | undefined;
+	};
+
+	it.each<FirstStatementCase>([
+		{
+			description: "FunctionDeclaration",
+			code: "function myFunction() {}",
+			expected: "myFunction",
+		},
+		{
+			description: "ClassDeclaration",
+			code: "class MyClass {}",
+			expected: "MyClass",
+		},
+		{
+			description: "InterfaceDeclaration",
+			code: "interface MyInterface {}",
+			expected: "MyInterface",
+		},
+		{
+			description: "TypeAliasDeclaration",
+			code: "type MyType = string;",
+			expected: "MyType",
+		},
+		{
+			description: "EnumDeclaration",
+			code: "enum MyEnum { A, B }",
+			expected: "MyEnum",
+		},
+		{
+			description: "VariableStatement (const)",
+			code: "const myVar = 10;",
+			expected: "myVar",
+		},
+		{
+			description: "VariableStatement (複数宣言、最初の識別子)",
+			code: "let var1 = 1, var2 = 2;",
+			expected: "var1",
+		},
+		{
+			description: "export された FunctionDeclaration",
+			code: "export function myFunction() {}",
+			expected: "myFunction",
+		},
+		{
+			description: "export default 名前付き FunctionDeclaration",
+			code: "export default function myFunction() {}",
+			expected: "myFunction",
+		},
+		{
+			description: "export default 匿名 FunctionDeclaration (識別子なし)",
+			code: "export default function() {}",
+			expected: undefined,
+		},
+		{
+			description: "ExportAssignment (オブジェクトリテラル、識別子なし)",
+			code: "export default { a: 1 };",
+			expected: undefined,
+		},
+		{
+			description: "サポート外 (ImportDeclaration)",
+			code: "import { x } from './other';",
+			expected: undefined,
+		},
+	])("$description の場合は $expected を返す", ({ code, expected }) => {
+		const identifier = getIdentifierFromDeclaration(getFirstStatement(code));
+		expect(identifier?.getText()).toBe(expected);
 	});
 
-	it("ClassDeclaration の識別子を返すこと", () => {
-		const statement = getFirstStatement("class MyClass {}");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier?.getText()).toBe("MyClass");
-	});
-
-	it("InterfaceDeclaration の識別子を返すこと", () => {
-		const statement = getFirstStatement("interface MyInterface {}");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier?.getText()).toBe("MyInterface");
-	});
-
-	it("TypeAliasDeclaration の識別子を返すこと", () => {
-		const statement = getFirstStatement("type MyType = string;");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier?.getText()).toBe("MyType");
-	});
-
-	it("EnumDeclaration の識別子を返すこと", () => {
-		const statement = getFirstStatement("enum MyEnum { A, B }");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier?.getText()).toBe("MyEnum");
-	});
-
-	it("VariableStatement (const) の識別子を返すこと", () => {
-		const statement = getFirstStatement("const myVar = 10;");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier?.getText()).toBe("myVar");
-	});
-
-	it("VariableStatement (複数宣言) の最初の識別子を返すこと", () => {
-		const statement = getFirstStatement("let var1 = 1, var2 = 2;");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier?.getText()).toBe("var1"); // 最初の宣言の識別子を返す仕様
-	});
-
-	it("エクスポートされた FunctionDeclaration の識別子を返すこと", () => {
-		const statement = getFirstStatement("export function myFunction() {}");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier?.getText()).toBe("myFunction");
-	});
-
-	it("デフォルトエクスポートされた名前付き FunctionDeclaration の識別子を返すこと", () => {
-		const statement = getFirstStatement(
-			"export default function myFunction() {}",
-		);
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier?.getText()).toBe("myFunction");
-	});
-
-	it("デフォルトエクスポートされた匿名 FunctionDeclaration では undefined を返すこと", () => {
-		const statement = getFirstStatement("export default function() {}");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier).toBeUndefined(); // 匿名なので名前がない
-	});
-
-	it("ExportAssignment (識別子) の識別子を返すこと", () => {
+	it("ExportAssignment (識別子) の識別子を返す", () => {
 		const project = createInMemoryProject();
 		const sourceFile = project.createSourceFile(
 			"test.ts",
 			"const foo = 1;\nexport default foo;",
 		);
 		const exportAssignment = sourceFile.getStatements()[1];
-		const identifier = getIdentifierFromDeclaration(exportAssignment);
-		expect(identifier?.getText()).toBe("foo");
+		expect(getIdentifierFromDeclaration(exportAssignment)?.getText()).toBe(
+			"foo",
+		);
 	});
 
-	it("ExportAssignment (非識別子) では undefined を返すこと", () => {
-		const statement = getFirstStatement("export default { a: 1 };");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier).toBeUndefined();
-	});
-
-	it("サポート外の Statement (ImportDeclarationなど) では undefined を返すこと", () => {
-		const statement = getFirstStatement("import { x } from './other';");
-		const identifier = getIdentifierFromDeclaration(statement);
-		expect(identifier).toBeUndefined();
-	});
-
-	it("undefined が入力された場合は undefined を返すこと", () => {
-		const identifier = getIdentifierFromDeclaration(undefined);
-		expect(identifier).toBeUndefined();
+	it("undefined が入力された場合は undefined を返す", () => {
+		expect(getIdentifierFromDeclaration(undefined)).toBeUndefined();
 	});
 });

--- a/src/ts-morph/move-symbol-to-file/generate-content/generate-new-source-file-content.test.ts
+++ b/src/ts-morph/move-symbol-to-file/generate-content/generate-new-source-file-content.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { Project, SyntaxKind, ts } from "ts-morph";
+import { type Project, SyntaxKind, ts } from "ts-morph";
+import { createInMemoryProject } from "../../_test-utils/create-in-memory-project";
 import { findTopLevelDeclarationByName } from "../find-declaration";
 import { generateNewSourceFileContent } from "./generate-new-source-file-content";
 import type {
@@ -7,13 +8,12 @@ import type {
 	NeededExternalImports,
 } from "../../types";
 
-// テストプロジェクト設定用ヘルパー
 const setupProjectWithCode = (
 	code: string,
 	filePath = "/src/original.ts",
 	project?: Project,
 ) => {
-	const proj = project ?? new Project({ useInMemoryFileSystem: true });
+	const proj = project ?? createInMemoryProject();
 	proj.compilerOptions.set({ jsx: ts.JsxEmit.ReactJSX });
 	const originalSourceFile = proj.createSourceFile(filePath, code);
 	return { project: proj, originalSourceFile };

--- a/src/ts-morph/move-symbol-to-file/internal-dependencies.test.ts
+++ b/src/ts-morph/move-symbol-to-file/internal-dependencies.test.ts
@@ -1,25 +1,16 @@
 import { describe, it, expect } from "vitest";
 import {
 	type FunctionDeclaration,
-	Project,
 	SyntaxKind,
 	type VariableStatement,
 } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { findTopLevelDeclarationByName } from "./find-declaration";
 import { getInternalDependencies } from "./internal-dependencies";
-// --- Test Setup Helper ---
-const setupProject = () => {
-	const project = new Project({
-		useInMemoryFileSystem: true,
-		compilerOptions: { target: 99, module: 99 },
-	});
-	project.createDirectory("/src");
-	return project;
-};
 
 describe("getInternalDependencies", () => {
 	it("関数宣言が依存する内部関数と内部変数を特定できる", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
 			filePath,
@@ -70,7 +61,7 @@ describe("getInternalDependencies", () => {
 	});
 
 	it("関数宣言が依存する内部変数を特定できる (間接依存)", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
 			filePath,
@@ -110,7 +101,7 @@ describe("getInternalDependencies", () => {
 	});
 
 	it("変数宣言が依存する内部変数を特定できる", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
 			filePath,
@@ -150,7 +141,7 @@ describe("getInternalDependencies", () => {
 	});
 
 	it("変数宣言が依存する内部変数を特定できる (直接依存)", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
 			filePath,
@@ -187,7 +178,7 @@ describe("getInternalDependencies", () => {
 	});
 
 	it("依存関係がない場合は空配列を返す", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
 			filePath,
@@ -224,7 +215,7 @@ describe("getInternalDependencies", () => {
 	});
 
 	it("関数宣言が依存する非エクスポートのアロー関数を特定できる", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const filePath = "/src/arrow-func-dep.ts";
 		const sourceFile = project.createSourceFile(
 			filePath,
@@ -254,7 +245,7 @@ describe("getInternalDependencies", () => {
 	});
 
 	it("複数の間接的な内部依存関係を再帰的に特定できる", () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const filePath = "/src/recursive-deps.ts";
 		const sourceFile = project.createSourceFile(
 			filePath,

--- a/src/ts-morph/move-symbol-to-file/internal-dependencies.test.ts
+++ b/src/ts-morph/move-symbol-to-file/internal-dependencies.test.ts
@@ -5,15 +5,31 @@ import {
 	type VariableStatement,
 } from "ts-morph";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
-import { findTopLevelDeclarationByName } from "./find-declaration";
+import { getStatement } from "../_test-utils/get-statement";
 import { getInternalDependencies } from "./internal-dependencies";
+
+const fnDecl = (sourceFile: Parameters<typeof getStatement>[0], name: string) =>
+	getStatement<FunctionDeclaration>(
+		sourceFile,
+		name,
+		SyntaxKind.FunctionDeclaration,
+	);
+
+const varStmt = (
+	sourceFile: Parameters<typeof getStatement>[0],
+	name: string,
+) =>
+	getStatement<VariableStatement>(
+		sourceFile,
+		name,
+		SyntaxKind.VariableStatement,
+	);
 
 describe("getInternalDependencies", () => {
 	it("関数宣言が依存する内部関数と内部変数を特定できる", () => {
 		const project = createInMemoryProject();
-		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
-			filePath,
+			"/src/test.ts",
 			`
 			const configValue = 10;
 			const calculatedValue = configValue * 2;
@@ -21,234 +37,125 @@ describe("getInternalDependencies", () => {
 			export function mainFunc(x: number): void { const result = helperFunc(x); console.log(result); }
 		`,
 		);
-		const mainFuncDecl = findTopLevelDeclarationByName(
-			sourceFile,
-			"mainFunc",
-			SyntaxKind.FunctionDeclaration,
-		) as FunctionDeclaration;
-		const helperFuncDecl = findTopLevelDeclarationByName(
-			sourceFile,
-			"helperFunc",
-			SyntaxKind.FunctionDeclaration,
-		) as FunctionDeclaration;
-		const calculatedValueStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"calculatedValue",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
-		const configValueStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"configValue",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
 
-		expect(mainFuncDecl).toBeDefined();
-		expect(helperFuncDecl).toBeDefined();
-		expect(calculatedValueStmt).toBeDefined();
-		expect(configValueStmt).toBeDefined();
+		const dependencies = getInternalDependencies(
+			fnDecl(sourceFile, "mainFunc"),
+		);
 
-		const dependencies = getInternalDependencies(mainFuncDecl);
-
-		expect(dependencies).toBeInstanceOf(Array);
-		expect(dependencies).toHaveLength(3); // helperFunc, calculatedValue, configValue
 		expect(dependencies).toEqual(
 			expect.arrayContaining([
-				helperFuncDecl,
-				calculatedValueStmt,
-				configValueStmt,
+				fnDecl(sourceFile, "helperFunc"),
+				varStmt(sourceFile, "calculatedValue"),
+				varStmt(sourceFile, "configValue"),
 			]),
 		);
+		expect(dependencies).toHaveLength(3);
 	});
 
 	it("関数宣言が依存する内部変数を特定できる (間接依存)", () => {
 		const project = createInMemoryProject();
-		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
-			filePath,
+			"/src/test.ts",
 			`
-			const configValue = 10; // <- さらに依存
-			const calculatedValue = configValue * 2; // <- 依存先
-			function helperFunc(n: number): number { return n + calculatedValue; } // <- これを対象
+			const configValue = 10;
+			const calculatedValue = configValue * 2;
+			function helperFunc(n: number): number { return n + calculatedValue; }
 		`,
 		);
-		const helperFuncDecl = findTopLevelDeclarationByName(
-			sourceFile,
-			"helperFunc",
-			SyntaxKind.FunctionDeclaration,
-		) as FunctionDeclaration;
-		const calculatedValueStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"calculatedValue",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
-		const configValueStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"configValue",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
 
-		expect(helperFuncDecl).toBeDefined();
-		expect(calculatedValueStmt).toBeDefined();
-		expect(configValueStmt).toBeDefined();
-
-		const dependencies = getInternalDependencies(helperFuncDecl);
-
-		expect(dependencies).toBeInstanceOf(Array);
-		expect(dependencies).toHaveLength(2); // calculatedValue, configValue
-		expect(dependencies).toEqual(
-			expect.arrayContaining([calculatedValueStmt, configValueStmt]),
+		const dependencies = getInternalDependencies(
+			fnDecl(sourceFile, "helperFunc"),
 		);
+
+		expect(dependencies).toEqual(
+			expect.arrayContaining([
+				varStmt(sourceFile, "calculatedValue"),
+				varStmt(sourceFile, "configValue"),
+			]),
+		);
+		expect(dependencies).toHaveLength(2);
 	});
 
 	it("変数宣言が依存する内部変数を特定できる", () => {
 		const project = createInMemoryProject();
-		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
-			filePath,
+			"/src/test.ts",
 			`
-			const configValue = 10; // <- さらに依存
-			const calculatedValue = configValue * 2; // <- 依存先
-			export const derivedConst = calculatedValue + 5; // <- これを対象
+			const configValue = 10;
+			const calculatedValue = configValue * 2;
+			export const derivedConst = calculatedValue + 5;
 		`,
 		);
-		const derivedConstStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"derivedConst",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
-		const calculatedValueStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"calculatedValue",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
-		const configValueStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"configValue",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
 
-		expect(derivedConstStmt).toBeDefined();
-		expect(calculatedValueStmt).toBeDefined();
-		expect(configValueStmt).toBeDefined();
-
-		const dependencies = getInternalDependencies(derivedConstStmt);
-
-		expect(dependencies).toBeInstanceOf(Array);
-		expect(dependencies).toHaveLength(2); // calculatedValue, configValue
-		expect(dependencies).toEqual(
-			expect.arrayContaining([calculatedValueStmt, configValueStmt]),
+		const dependencies = getInternalDependencies(
+			varStmt(sourceFile, "derivedConst"),
 		);
+
+		expect(dependencies).toEqual(
+			expect.arrayContaining([
+				varStmt(sourceFile, "calculatedValue"),
+				varStmt(sourceFile, "configValue"),
+			]),
+		);
+		expect(dependencies).toHaveLength(2);
 	});
 
 	it("変数宣言が依存する内部変数を特定できる (直接依存)", () => {
 		const project = createInMemoryProject();
-		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
-			filePath,
+			"/src/test.ts",
 			`
-				const configValue = 10; // <- 依存先
-				const calculatedValue = configValue * 2; // <- これを対象
-			`,
+			const configValue = 10;
+			const calculatedValue = configValue * 2;
+		`,
 		);
-		const calculatedValueStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"calculatedValue",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
-		const configValueStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"configValue",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
 
-		expect(
-			calculatedValueStmt,
-			"Test setup failed: calculatedValue not found",
-		).toBeDefined();
-		expect(
-			configValueStmt,
-			"Test setup failed: configValue not found",
-		).toBeDefined();
+		const dependencies = getInternalDependencies(
+			varStmt(sourceFile, "calculatedValue"),
+		);
 
-		const dependencies = getInternalDependencies(calculatedValueStmt);
-
-		expect(dependencies).toBeInstanceOf(Array);
-		expect(dependencies).toHaveLength(1);
-		expect(dependencies[0]).toBe(configValueStmt);
+		expect(dependencies).toEqual([varStmt(sourceFile, "configValue")]);
 	});
 
 	it("依存関係がない場合は空配列を返す", () => {
 		const project = createInMemoryProject();
-		const filePath = "/src/internal-deps-advanced.ts";
 		const sourceFile = project.createSourceFile(
-			filePath,
+			"/src/test.ts",
 			`
 			const configValue = 10;
 			function unusedFunc() {}
 		`,
 		);
-		const configValueStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"configValue",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
-		const unusedFuncDecl = findTopLevelDeclarationByName(
-			sourceFile,
-			"unusedFunc",
-			SyntaxKind.FunctionDeclaration,
-		) as FunctionDeclaration;
 
-		expect(
-			configValueStmt,
-			"Test setup failed: configValue not found",
-		).toBeDefined();
-		expect(
-			unusedFuncDecl,
-			"Test setup failed: unusedFunc not found",
-		).toBeDefined();
-
-		const configDeps = getInternalDependencies(configValueStmt);
-		const unusedDeps = getInternalDependencies(unusedFuncDecl);
-
-		expect(configDeps).toEqual([]);
-		expect(unusedDeps).toEqual([]);
+		expect(getInternalDependencies(varStmt(sourceFile, "configValue"))).toEqual(
+			[],
+		);
+		expect(getInternalDependencies(fnDecl(sourceFile, "unusedFunc"))).toEqual(
+			[],
+		);
 	});
 
 	it("関数宣言が依存する非エクスポートのアロー関数を特定できる", () => {
 		const project = createInMemoryProject();
-		const filePath = "/src/arrow-func-dep.ts";
 		const sourceFile = project.createSourceFile(
-			filePath,
+			"/src/test.ts",
 			`
 			const arrowHelper = (n: number): number => n * n;
 			export function mainFunc(x: number): number { return arrowHelper(x); }
 		`,
 		);
-		const mainFuncDecl = findTopLevelDeclarationByName(
-			sourceFile,
-			"mainFunc",
-			SyntaxKind.FunctionDeclaration,
-		) as FunctionDeclaration;
-		const arrowHelperStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"arrowHelper",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
 
-		expect(mainFuncDecl).toBeDefined();
-		expect(arrowHelperStmt).toBeDefined();
+		const dependencies = getInternalDependencies(
+			fnDecl(sourceFile, "mainFunc"),
+		);
 
-		const dependencies = getInternalDependencies(mainFuncDecl);
-
-		expect(dependencies.length).toBe(1);
-		expect(dependencies[0]).toBe(arrowHelperStmt);
+		expect(dependencies).toEqual([varStmt(sourceFile, "arrowHelper")]);
 	});
 
 	it("複数の間接的な内部依存関係を再帰的に特定できる", () => {
 		const project = createInMemoryProject();
-		const filePath = "/src/recursive-deps.ts";
 		const sourceFile = project.createSourceFile(
-			filePath,
+			"/src/test.ts",
 			`
 			const d = 4;
 			const c = () => d;
@@ -257,36 +164,16 @@ describe("getInternalDependencies", () => {
 			const e = () => d; // d は a 以外からも参照されるが、ここでは a の依存のみ見る
 		`,
 		);
-		const aStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"a",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
-		const bStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"b",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
-		const cStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"c",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
-		const dStmt = findTopLevelDeclarationByName(
-			sourceFile,
-			"d",
-			SyntaxKind.VariableStatement,
-		) as VariableStatement;
 
-		expect(aStmt).toBeDefined();
-		expect(bStmt).toBeDefined();
-		expect(cStmt).toBeDefined();
-		expect(dStmt).toBeDefined();
+		const dependencies = getInternalDependencies(varStmt(sourceFile, "a"));
 
-		const dependencies = getInternalDependencies(aStmt);
-
-		expect(dependencies).toBeInstanceOf(Array);
-		expect(dependencies).toHaveLength(3); // b, c, d が含まれるはず
-		expect(dependencies).toEqual(expect.arrayContaining([bStmt, cStmt, dStmt]));
+		expect(dependencies).toEqual(
+			expect.arrayContaining([
+				varStmt(sourceFile, "b"),
+				varStmt(sourceFile, "c"),
+				varStmt(sourceFile, "d"),
+			]),
+		);
+		expect(dependencies).toHaveLength(3);
 	});
 });

--- a/src/ts-morph/move-symbol-to-file/internal-dependencies.test.ts
+++ b/src/ts-morph/move-symbol-to-file/internal-dependencies.test.ts
@@ -1,29 +1,14 @@
 import { describe, it, expect } from "vitest";
-import {
-	type FunctionDeclaration,
-	SyntaxKind,
-	type VariableStatement,
-} from "ts-morph";
+import { type SourceFile, SyntaxKind } from "ts-morph";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { getStatement } from "../_test-utils/get-statement";
 import { getInternalDependencies } from "./internal-dependencies";
 
-const fnDecl = (sourceFile: Parameters<typeof getStatement>[0], name: string) =>
-	getStatement<FunctionDeclaration>(
-		sourceFile,
-		name,
-		SyntaxKind.FunctionDeclaration,
-	);
+const fnDecl = (sourceFile: SourceFile, name: string) =>
+	getStatement(sourceFile, name, SyntaxKind.FunctionDeclaration);
 
-const varStmt = (
-	sourceFile: Parameters<typeof getStatement>[0],
-	name: string,
-) =>
-	getStatement<VariableStatement>(
-		sourceFile,
-		name,
-		SyntaxKind.VariableStatement,
-	);
+const varStmt = (sourceFile: SourceFile, name: string) =>
+	getStatement(sourceFile, name, SyntaxKind.VariableStatement);
 
 describe("getInternalDependencies", () => {
 	it("関数宣言が依存する内部関数と内部変数を特定できる", () => {
@@ -110,11 +95,13 @@ describe("getInternalDependencies", () => {
 		`,
 		);
 
+		const configValueStmt = varStmt(sourceFile, "configValue");
 		const dependencies = getInternalDependencies(
 			varStmt(sourceFile, "calculatedValue"),
 		);
 
-		expect(dependencies).toEqual([varStmt(sourceFile, "configValue")]);
+		expect(dependencies).toHaveLength(1);
+		expect(dependencies[0]).toBe(configValueStmt);
 	});
 
 	it("依存関係がない場合は空配列を返す", () => {

--- a/src/ts-morph/move-symbol-to-file/move-symbol-to-file.dependencies.test.ts
+++ b/src/ts-morph/move-symbol-to-file/move-symbol-to-file.dependencies.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { SyntaxKind } from "ts-morph";
 import { createInMemoryProjectWithDoubleQuotes } from "../_test-utils/create-in-memory-project";
+import { getFileText } from "../_test-utils/get-file-text";
 import { moveSymbolToFile } from "./move-symbol-to-file";
 
 describe("moveSymbolToFile (Dependency Cases)", () => {
@@ -33,7 +34,7 @@ console.log(dependentFunc());`,
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`const baseValue = 100;
 
 export const dependentFunc = () => {
@@ -41,11 +42,11 @@ export const dependentFunc = () => {
 };
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export const anotherThing = 'keep me';
 `,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import { dependentFunc } from './moved-module';
 console.log(dependentFunc());`,
 		);
@@ -83,7 +84,7 @@ console.log(featureAFunc());`,
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`import { sharedUtil } from "./shared-logic";
 
 export const featureAFunc = () => {
@@ -91,13 +92,13 @@ export const featureAFunc = () => {
 };
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export const sharedUtil = { value: 'shared' }; // export しておく必要がある
 export const anotherFunc = () => {
   return 'Another using ' + sharedUtil.value;
 };`,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import { featureAFunc } from './feature-a';
 console.log(featureAFunc());`,
 		);
@@ -130,7 +131,7 @@ export const generateReport = (data: number[]) => {
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`import { internalCalculator } from "./core-utils";
 
 export const formatDisplayValue = (val: number) => {
@@ -138,7 +139,7 @@ export const formatDisplayValue = (val: number) => {
 };
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export const internalCalculator = (x: number) => x * x; // export なし
 export const generateReport = (data: number[]) => {
   const total = data.reduce((sum, x) => sum + internalCalculator(x), 0);
@@ -172,12 +173,12 @@ export function mainFunc(): string {
 			SyntaxKind.FunctionDeclaration,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText().trim()).toBe(
+		expect(getFileText(project, newFilePath).trim()).toBe(
 			`export function helperFunc(): string {
   return 'Helper result';
 }`,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText().trim()).toBe(
+		expect(getFileText(project, oldFilePath).trim()).toBe(
 			`import { helperFunc } from "./helper";
 
 export function mainFunc(): string {
@@ -216,7 +217,7 @@ console.log(resolved);`,
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`import * as path from "node:path";
 
 export const resolvePath = (p1: string, p2: string): string => {
@@ -224,8 +225,8 @@ export const resolvePath = (p1: string, p2: string): string => {
 };
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText().trim()).toBe("");
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath).trim()).toBe("");
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import { resolvePath } from './moved-path-utils';
 const resolved = resolvePath('/foo', 'bar');
 console.log(resolved);`,
@@ -265,7 +266,7 @@ console.log(moveMe());`,
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(project.getSourceFile(existingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, existingFilePath)).toBe(
 			`import { alreadyImported } from './source';
 
 export const keepMe = 'I was already here';
@@ -274,10 +275,10 @@ console.log('Existing code using:', alreadyImported);
 
 export const moveMe = () => 'I was moved';`,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export const alreadyImported = 'Imported before move';`,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import { moveMe } from './destination';
 console.log(moveMe());`,
 		);

--- a/src/ts-morph/move-symbol-to-file/move-symbol-to-file.dependencies.test.ts
+++ b/src/ts-morph/move-symbol-to-file/move-symbol-to-file.dependencies.test.ts
@@ -160,6 +160,7 @@ export const generateReport = (data: number[]) => {
 }
 
 export function mainFunc(): string {
+  // helperFunc を使用
   const result = helperFunc();
   return \`Main using \${result}\`;
 }`,
@@ -178,10 +179,12 @@ export function mainFunc(): string {
   return 'Helper result';
 }`,
 		);
+		// import 挿入時に関数本文内のコメントが保持されることを保証する
 		expect(getFileText(project, oldFilePath).trim()).toBe(
 			`import { helperFunc } from "./helper";
 
 export function mainFunc(): string {
+  // helperFunc を使用
   const result = helperFunc();
   return \`Main using \${result}\`;
 }`,

--- a/src/ts-morph/move-symbol-to-file/move-symbol-to-file.dependencies.test.ts
+++ b/src/ts-morph/move-symbol-to-file/move-symbol-to-file.dependencies.test.ts
@@ -1,234 +1,165 @@
 import { describe, it, expect } from "vitest";
-import { Project, IndentationText, QuoteKind, SyntaxKind } from "ts-morph";
+import { SyntaxKind } from "ts-morph";
+import { createInMemoryProjectWithDoubleQuotes } from "../_test-utils/create-in-memory-project";
 import { moveSymbolToFile } from "./move-symbol-to-file";
 
 describe("moveSymbolToFile (Dependency Cases)", () => {
 	it("同じファイル内の他のシンボルに依存するシンボルを移動し、依存関係も新しいファイルに含める", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double, // プロジェクト規約に合わせておく
-			},
-			compilerOptions: { baseUrl: ".", paths: { "@/*": ["src/*"] } },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/module.ts";
 		const newFilePath = "/src/moved-module.ts";
-		const symbolToMove = "dependentFunc";
-		const dependencySymbol = "baseValue"; // 移動しない内部依存
 		const referencingFilePath = "/src/user.ts";
-		const anotherThing = "anotherThing"; // 移動しない他のシンボル
 
-		// 移動元のファイル
-		const oldSourceFile = project.createSourceFile(
+		project.createSourceFile(
 			oldFilePath,
-			`const ${dependencySymbol} = 100;
-export const ${symbolToMove} = () => {
-  return ${dependencySymbol} * 2;
+			`const baseValue = 100;
+export const dependentFunc = () => {
+  return baseValue * 2;
 };
-export const ${anotherThing} = 'keep me';
+export const anotherThing = 'keep me';
 `,
 		);
-
-		// 参照元のファイル
-		const referencingSourceFile = project.createSourceFile(
+		project.createSourceFile(
 			referencingFilePath,
-			`import { ${symbolToMove} } from './module';
-console.log(${symbolToMove}());`,
+			`import { dependentFunc } from './module';
+console.log(dependentFunc());`,
 		);
 
 		await moveSymbolToFile(
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
+			"dependentFunc",
 			SyntaxKind.VariableStatement,
 		);
 
-		// 1. 新しいファイルの内容確認
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `const baseValue = 100;
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`const baseValue = 100;
 
 export const dependentFunc = () => {
   return baseValue * 2;
 };
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
-
-		// 2. 元のファイルの内容確認
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export const anotherThing = 'keep me';
-`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		// 3. 参照元のインポートパス確認
-		const updatedReferencingSourceFile =
-			project.getSourceFile(referencingFilePath); // 再取得
-		const expectedReferencingContent = `import { dependentFunc } from './moved-module';
-console.log(dependentFunc());`;
-		expect(updatedReferencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export const anotherThing = 'keep me';
+`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import { dependentFunc } from './moved-module';
+console.log(dependentFunc());`,
 		);
 	});
 
 	it("他に参照される内部依存シンボルがある場合、そのシンボルは元ファイルに残り、新しいファイルからインポートされる", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: "." },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/shared-logic.ts";
 		const newFilePath = "/src/feature-a.ts";
-		const symbolToMove = "featureAFunc";
-		const sharedDependency = "sharedUtil"; // 他からも参照される内部依存
-		const anotherUser = "anotherFunc"; // sharedUtil を使う他の関数
 		const referencingFilePath = "/src/consumer.ts";
 
-		// 移動元のファイル
-		const oldSourceFile = project.createSourceFile(
-			oldFilePath,
-			`export const ${sharedDependency} = { value: 'shared' }; // export しておく必要がある
-
-export const ${symbolToMove} = () => {
-  return 'Feature A using ' + ${sharedDependency}.value;
-};
-
-export const ${anotherUser} = () => {
-  return 'Another using ' + ${sharedDependency}.value;
-};`,
-		);
-
-		// featureAFunc を使うファイル (参照更新の確認用)
 		project.createSourceFile(
-			referencingFilePath,
-			`import { ${symbolToMove} } from './shared-logic';
-console.log(${symbolToMove}());`,
-		);
-
-		await moveSymbolToFile(
-			project,
 			oldFilePath,
-			newFilePath,
-			symbolToMove,
-			SyntaxKind.VariableStatement,
-		);
-
-		// 1. 新しいファイルの内容確認
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `import { sharedUtil } from "./shared-logic";
+			`export const sharedUtil = { value: 'shared' }; // export しておく必要がある
 
 export const featureAFunc = () => {
   return 'Feature A using ' + sharedUtil.value;
 };
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
 
-		// 2. 元のファイルの内容確認
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export const sharedUtil = { value: 'shared' }; // export しておく必要がある
 export const anotherFunc = () => {
   return 'Another using ' + sharedUtil.value;
-};`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		// 3. 参照元のインポートパス確認
-		const updatedReferencingSourceFile =
-			project.getSourceFile(referencingFilePath); // 再取得
-		const expectedReferencingContent = `import { featureAFunc } from './feature-a';
-console.log(featureAFunc());`;
-		expect(updatedReferencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
-		);
-	});
-
-	it("exportされていない内部依存シンボルが他からも参照される場合、元ファイルにexportが追加され、新しいファイルからインポートされる", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: "." },
-		});
-
-		const oldFilePath = "/src/core-utils.ts";
-		const newFilePath = "/src/ui-helper.ts";
-		const symbolToMove = "formatDisplayValue";
-		const nonExportedDependency = "internalCalculator";
-		const anotherUser = "generateReport"; // internalCalculator を使う他の関数
-
-		// 移動元のファイル
-		const oldSourceFile = project.createSourceFile(
-			oldFilePath,
-			`const ${nonExportedDependency} = (x: number) => x * x; // export なし
-
-export const ${symbolToMove} = (val: number) => {
-  return \`Value: \${${nonExportedDependency}(val)}\`;
-};
-
-export const ${anotherUser} = (data: number[]) => {
-  const total = data.reduce((sum, x) => sum + ${nonExportedDependency}(x), 0);
-  return \`Report Total: \${total}\`;
 };`,
 		);
+		project.createSourceFile(
+			referencingFilePath,
+			`import { featureAFunc } from './shared-logic';
+console.log(featureAFunc());`,
+		);
+
 		await moveSymbolToFile(
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
+			"featureAFunc",
 			SyntaxKind.VariableStatement,
 		);
 
-		// 1. 新しいファイルの内容確認
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `import { internalCalculator } from "./core-utils";
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`import { sharedUtil } from "./shared-logic";
+
+export const featureAFunc = () => {
+  return 'Feature A using ' + sharedUtil.value;
+};
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export const sharedUtil = { value: 'shared' }; // export しておく必要がある
+export const anotherFunc = () => {
+  return 'Another using ' + sharedUtil.value;
+};`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import { featureAFunc } from './feature-a';
+console.log(featureAFunc());`,
+		);
+	});
+
+	it("exportされていない内部依存シンボルが他からも参照される場合、元ファイルにexportが追加され、新しいファイルからインポートされる", async () => {
+		const project = createInMemoryProjectWithDoubleQuotes();
+		const oldFilePath = "/src/core-utils.ts";
+		const newFilePath = "/src/ui-helper.ts";
+
+		project.createSourceFile(
+			oldFilePath,
+			`const internalCalculator = (x: number) => x * x; // export なし
 
 export const formatDisplayValue = (val: number) => {
   return \`Value: \${internalCalculator(val)}\`;
 };
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
 
-		// 2. 元のファイルの内容確認
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export const internalCalculator = (x: number) => x * x; // export なし
 export const generateReport = (data: number[]) => {
   const total = data.reduce((sum, x) => sum + internalCalculator(x), 0);
   return \`Report Total: \${total}\`;
-};`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
+};`,
+		);
+
+		await moveSymbolToFile(
+			project,
+			oldFilePath,
+			newFilePath,
+			"formatDisplayValue",
+			SyntaxKind.VariableStatement,
+		);
+
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`import { internalCalculator } from "./core-utils";
+
+export const formatDisplayValue = (val: number) => {
+  return \`Value: \${internalCalculator(val)}\`;
+};
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export const internalCalculator = (x: number) => x * x; // export なし
+export const generateReport = (data: number[]) => {
+  const total = data.reduce((sum, x) => sum + internalCalculator(x), 0);
+  return \`Report Total: \${total}\`;
+};`,
+		);
 	});
 
 	it("移動したシンボルが移動元のファイル内で使われていた場合、移動元にインポート文が追加される", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double, // プロジェクト規約に合わせておく
-			},
-			compilerOptions: { baseUrl: "." },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/original.ts";
 		const newFilePath = "/src/helper.ts";
-		const symbolToMove = "helperFunc"; // 移動対象
-		const userSymbol = "mainFunc"; // helperFunc を使う関数
 
-		// 移動元のファイル
 		project.createSourceFile(
 			oldFilePath,
-			`function ${symbolToMove}(): string {
+			`function helperFunc(): string {
   return 'Helper result';
 }
 
-export function ${userSymbol}(): string {
-  // helperFunc を使用
-  const result = ${symbolToMove}();
+export function mainFunc(): string {
+  const result = helperFunc();
   return \`Main using \${result}\`;
 }`,
 		);
@@ -237,59 +168,43 @@ export function ${userSymbol}(): string {
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
-			SyntaxKind.FunctionDeclaration, // 移動するのは関数宣言
+			"helperFunc",
+			SyntaxKind.FunctionDeclaration,
 		);
 
-		// 1. 新しいファイルの内容確認
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `export function helperFunc(): string {\n  return 'Helper result';\n}\n`;
-		expect(newSourceFile?.getFullText().trim()).toBe(expectedNewContent.trim());
-
-		// 2. 元のファイルの内容確認
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `import { helperFunc } from "./helper";
+		expect(project.getSourceFile(newFilePath)?.getFullText().trim()).toBe(
+			`export function helperFunc(): string {
+  return 'Helper result';
+}`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText().trim()).toBe(
+			`import { helperFunc } from "./helper";
 
 export function mainFunc(): string {
-  // helperFunc を使用
   const result = helperFunc();
   return \`Main using \${result}\`;
-}\n`;
-		expect(updatedOldSourceFile?.getFullText().trim()).toBe(
-			expectedOldContent.trim(),
+}`,
 		);
 	});
 
 	it("名前空間インポート (import * as) に依存するシンボルを移動する", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: ".", esModuleInterop: true }, // esModuleInterop を有効にする必要がある場合がある
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/path-utils.ts";
 		const newFilePath = "/src/moved-path-utils.ts";
-		const symbolToMove = "resolvePath";
 		const referencingFilePath = "/src/main.ts";
 
-		// 移動元のファイル
 		project.createSourceFile(
 			oldFilePath,
-			`import * as path from 'node:path'; // 名前空間インポート
+			`import * as path from 'node:path';
 
-export const ${symbolToMove} = (p1: string, p2: string): string => {
+export const resolvePath = (p1: string, p2: string): string => {
   return path.resolve(p1, p2);
 };`,
 		);
-
-		// 参照元のファイル
 		project.createSourceFile(
 			referencingFilePath,
-			`import { ${symbolToMove} } from './path-utils';
-const resolved = ${symbolToMove}('/foo', 'bar');
+			`import { resolvePath } from './path-utils';
+const resolved = resolvePath('/foo', 'bar');
 console.log(resolved);`,
 		);
 
@@ -297,108 +212,74 @@ console.log(resolved);`,
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
+			"resolvePath",
 			SyntaxKind.VariableStatement,
 		);
 
-		// 1. 新しいファイルの内容確認 (★ import * as path が含まれるべき)
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `import * as path from "node:path";
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`import * as path from "node:path";
 
 export const resolvePath = (p1: string, p2: string): string => {
   return path.resolve(p1, p2);
 };
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
-
-		// 2. 元のファイルの内容確認 (空になるはず)
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		expect(updatedOldSourceFile?.getFullText().trim()).toBe("");
-
-		// 3. 参照元のインポートパス確認
-		const updatedReferencingSourceFile =
-			project.getSourceFile(referencingFilePath);
-		const expectedReferencingContent = `import { resolvePath } from './moved-path-utils';
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText().trim()).toBe("");
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import { resolvePath } from './moved-path-utils';
 const resolved = resolvePath('/foo', 'bar');
-console.log(resolved);`;
-		expect(updatedReferencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+console.log(resolved);`,
 		);
 	});
 
 	it("既存のファイルにシンボルを移動し、既存の内容とマージされる（移動元から既にインポートがある場合）", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: "." },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/source.ts";
-		const existingFilePath = "/src/destination.ts"; // 移動先の既存ファイル
-		const symbolToMove = "moveMe";
-		const existingSymbol = "keepMe";
-		const alreadyImportedSymbol = "alreadyImported"; // ★ 移動前からインポートされているシンボル
+		const existingFilePath = "/src/destination.ts";
 		const referencingFilePath = "/src/user.ts";
 
-		// 移動元のファイル (移動対象 + 既存ファイルがインポートしているシンボル)
 		project.createSourceFile(
 			oldFilePath,
-			`export const ${alreadyImportedSymbol} = 'Imported before move';
-export const ${symbolToMove} = () => 'I was moved';`,
+			`export const alreadyImported = 'Imported before move';
+export const moveMe = () => 'I was moved';`,
 		);
-
-		// ★ 移動先の既存ファイル (alreadyImportedSymbol をインポート済み)
 		project.createSourceFile(
 			existingFilePath,
-			`import { ${alreadyImportedSymbol} } from './source';
+			`import { alreadyImported } from './source';
 
-export const ${existingSymbol} = 'I was already here';
+export const keepMe = 'I was already here';
 
-console.log('Existing code using:', ${alreadyImportedSymbol});`,
+console.log('Existing code using:', alreadyImported);`,
 		);
-
-		// 参照元のファイル (moveMe を使用)
 		project.createSourceFile(
 			referencingFilePath,
-			`import { ${symbolToMove} } from './source';
-console.log(${symbolToMove}());`,
+			`import { moveMe } from './source';
+console.log(moveMe());`,
 		);
 
 		await moveSymbolToFile(
 			project,
 			oldFilePath,
 			existingFilePath,
-			symbolToMove,
+			"moveMe",
 			SyntaxKind.VariableStatement,
 		);
 
-		// 1. 移動先のファイルの内容確認
-		const updatedExistingFile = project.getSourceFile(existingFilePath);
-		// ★ 既存のインポートは維持され、移動したシンボルが追加される
-		const expectedExistingContent = `import { alreadyImported } from './source';
+		expect(project.getSourceFile(existingFilePath)?.getFullText()).toBe(
+			`import { alreadyImported } from './source';
 
 export const keepMe = 'I was already here';
 
 console.log('Existing code using:', alreadyImported);
 
-export const moveMe = () => 'I was moved';`;
-		expect(updatedExistingFile?.getFullText()).toBe(expectedExistingContent);
-
-		// 2. 元のファイルの内容確認 (alreadyImportedSymbol のみが残る)
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export const ${alreadyImportedSymbol} = 'Imported before move';`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		// 3. 参照元のインポートパス確認 (moveMe のインポート先が destination に変わる)
-		const updatedReferencingSourceFile =
-			project.getSourceFile(referencingFilePath);
-		const expectedReferencingContent = `import { moveMe } from './destination';
-console.log(moveMe());`;
-		expect(updatedReferencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+export const moveMe = () => 'I was moved';`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export const alreadyImported = 'Imported before move';`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import { moveMe } from './destination';
+console.log(moveMe());`,
 		);
 	});
 });

--- a/src/ts-morph/move-symbol-to-file/move-symbol-to-file.test.ts
+++ b/src/ts-morph/move-symbol-to-file/move-symbol-to-file.test.ts
@@ -1,32 +1,21 @@
 import { describe, it, expect } from "vitest";
-import { Project, IndentationText, QuoteKind, SyntaxKind } from "ts-morph";
+import { SyntaxKind } from "ts-morph";
+import { createInMemoryProjectWithDoubleQuotes } from "../_test-utils/create-in-memory-project";
 import { moveSymbolToFile } from "./move-symbol-to-file";
 
 describe("moveSymbolToFile", () => {
 	it("指定された const シンボルを新しいファイルに移動し、参照を更新する", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: ".", paths: { "@/*": ["src/*"] } },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/utils.ts";
 		const newFilePath = "/src/new-utils.ts";
-		const symbolToMove = "myUtil";
 		const referencingFilePath = "/src/component.ts";
 
-		// 移動元のファイル
 		project.createSourceFile(
 			oldFilePath,
 			`export const myUtil = () => 'utility';
 export const anotherUtil = 1;
 `,
 		);
-
-		// 参照元のファイル
 		project.createSourceFile(
 			referencingFilePath,
 			`import { myUtil } from "./utils";
@@ -38,56 +27,37 @@ console.log(myUtil());
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
-			SyntaxKind.VariableStatement, // const は VariableStatement
+			"myUtil",
+			SyntaxKind.VariableStatement,
 		);
 
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `export const myUtil = () => 'utility';
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
-
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		// 元のファイルからシンボルが削除され、他のシンボルは残る
-		const expectedOldContent = `export const anotherUtil = 1;
-`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		const referencingSourceFile = project.getSourceFile(referencingFilePath);
-		const expectedReferencingContent = `import { myUtil } from "./new-utils";
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`export const myUtil = () => 'utility';
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export const anotherUtil = 1;
+`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import { myUtil } from "./new-utils";
 console.log(myUtil());
-`;
-		expect(referencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+`,
 		);
 	});
 
 	it("外部依存関係を持つシンボルを移動し、新しいファイルにインポートを追加する", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: ".", paths: { "@/*": ["src/*"] } },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const dependencyFilePath = "/src/dependency.ts";
 		const oldFilePath = "/src/source.ts";
 		const newFilePath = "/src/new-location.ts";
 		const referencingFilePath = "/src/importer.ts";
 
-		const dependencySymbol = "dependencyFunc";
-		const symbolToMove = "symbolUsingDependency";
-
-		// 依存ファイル
 		project.createSourceFile(
 			dependencyFilePath,
 			`export const dependencyFunc = () => 'dependency result';
 `,
 		);
-
-		// 移動元のファイル (依存関係をインポートして使用)
 		project.createSourceFile(
 			oldFilePath,
 			`import { dependencyFunc } from "./dependency";
@@ -97,8 +67,6 @@ export const symbolUsingDependency = () => {
 export const anotherInSource = true;
 `,
 		);
-
-		// 参照元のファイル
 		project.createSourceFile(
 			referencingFilePath,
 			`import { symbolUsingDependency } from "./source";
@@ -110,58 +78,41 @@ console.log(symbolUsingDependency());
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
+			"symbolUsingDependency",
 			SyntaxKind.VariableStatement,
 		);
 
-		const newSourceFile = project.getSourceFile(newFilePath);
-		// 移動されたシンボルの定義と依存関係のインポートが含まれる
-		const expectedNewContent = `import { dependencyFunc } from "./dependency";
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`import { dependencyFunc } from "./dependency";
 
 export const symbolUsingDependency = () => {
   return 'using ' + dependencyFunc();
 };
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
-
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export const anotherInSource = true;
-`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		const referencingSourceFile = project.getSourceFile(referencingFilePath);
-		const expectedReferencingContent = `import { symbolUsingDependency } from "./new-location";
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export const anotherInSource = true;
+`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import { symbolUsingDependency } from "./new-location";
 console.log(symbolUsingDependency());
-`;
-		expect(referencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+`,
 		);
 	});
 
 	it("指定された function シンボルを新しいファイルに移動し、参照を更新する", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: ".", paths: { "@/*": ["src/*"] } },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/functions.ts";
 		const newFilePath = "/src/new-functions.ts";
-		const symbolToMove = "myFunction";
 		const referencingFilePath = "/src/caller.ts";
 
-		// 移動元のファイル
 		project.createSourceFile(
 			oldFilePath,
 			`export function myFunction() { return 'hello'; }
 export const anotherValue = 42;
 `,
 		);
-
-		// 参照元のファイル
 		project.createSourceFile(
 			referencingFilePath,
 			`import { myFunction } from "./functions";
@@ -173,53 +124,37 @@ myFunction();
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
-			SyntaxKind.FunctionDeclaration, // function は FunctionDeclaration
+			"myFunction",
+			SyntaxKind.FunctionDeclaration,
 		);
 
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `export function myFunction() { return 'hello'; }
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
-
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export const anotherValue = 42;
-`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		const referencingSourceFile = project.getSourceFile(referencingFilePath);
-		const expectedReferencingContent = `import { myFunction } from "./new-functions";
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`export function myFunction() { return 'hello'; }
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export const anotherValue = 42;
+`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import { myFunction } from "./new-functions";
 myFunction();
-`;
-		expect(referencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+`,
 		);
 	});
 
 	it("指定された class シンボルを新しいファイルに移動し、参照を更新する", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: ".", paths: { "@/*": ["src/*"] } },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/models.ts";
 		const newFilePath = "/src/new-models.ts";
-		const symbolToMove = "MyClass";
 		const referencingFilePath = "/src/user.ts";
 
-		// 移動元のファイル
 		project.createSourceFile(
 			oldFilePath,
 			`export class MyClass { constructor() { console.log("Model created"); } }
 export interface AnotherInterface {}
 `,
 		);
-
-		// 参照元のファイル
 		project.createSourceFile(
 			referencingFilePath,
 			`import { MyClass } from "./models";
@@ -231,53 +166,37 @@ const instance = new MyClass();
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
+			"MyClass",
 			SyntaxKind.ClassDeclaration,
 		);
 
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `export class MyClass { constructor() { console.log("Model created"); } }
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
-
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export interface AnotherInterface {}
-`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		const referencingSourceFile = project.getSourceFile(referencingFilePath);
-		const expectedReferencingContent = `import { MyClass } from "./new-models";
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`export class MyClass { constructor() { console.log("Model created"); } }
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export interface AnotherInterface {}
+`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import { MyClass } from "./new-models";
 const instance = new MyClass();
-`;
-		expect(referencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+`,
 		);
 	});
 
 	it("指定された interface シンボルを新しいファイルに移動し、参照を更新する", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: ".", paths: { "@/*": ["src/*"] } },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/types.ts";
 		const newFilePath = "/src/new-types.ts";
-		const symbolToMove = "MyInterface";
 		const referencingFilePath = "/src/data.ts";
 
-		// 移動元のファイル
 		project.createSourceFile(
 			oldFilePath,
 			`export interface MyInterface { id: string; }
 export type AnotherType = number;
 `,
 		);
-
-		// 参照元のファイル
 		project.createSourceFile(
 			referencingFilePath,
 			`import type { MyInterface } from "./types";
@@ -288,53 +207,36 @@ const data: MyInterface = { id: '1' };`,
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
+			"MyInterface",
 			SyntaxKind.InterfaceDeclaration,
 		);
 
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `export interface MyInterface { id: string; }
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
-
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export type AnotherType = number;
-`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		const referencingSourceFile = project.getSourceFile(referencingFilePath);
-		// `import type` も正しく更新される
-		const expectedReferencingContent = `import type { MyInterface } from "./new-types";
-const data: MyInterface = { id: '1' };`;
-		expect(referencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`export interface MyInterface { id: string; }
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export type AnotherType = number;
+`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import type { MyInterface } from "./new-types";
+const data: MyInterface = { id: '1' };`,
 		);
 	});
 
 	it("指定された type alias シンボルを新しいファイルに移動し、参照を更新する", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: ".", paths: { "@/*": ["src/*"] } },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/aliases.ts";
 		const newFilePath = "/src/new-aliases.ts";
-		const symbolToMove = "MyType";
 		const referencingFilePath = "/src/config.ts";
 
-		// 移動元のファイル
 		project.createSourceFile(
 			oldFilePath,
 			`export type MyType = string | number;
 export const CONFIG_KEY = 'key';
 `,
 		);
-
-		// 参照元のファイル
 		project.createSourceFile(
 			referencingFilePath,
 			`import type { MyType } from "./aliases";
@@ -346,53 +248,37 @@ let value: MyType = 'test';
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
+			"MyType",
 			SyntaxKind.TypeAliasDeclaration,
 		);
 
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `export type MyType = string | number;
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
-
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export const CONFIG_KEY = 'key';
-`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		const referencingSourceFile = project.getSourceFile(referencingFilePath);
-		const expectedReferencingContent = `import type { MyType } from "./new-aliases";
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`export type MyType = string | number;
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export const CONFIG_KEY = 'key';
+`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import type { MyType } from "./new-aliases";
 let value: MyType = 'test';
-`;
-		expect(referencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+`,
 		);
 	});
 
 	it("指定された enum シンボルを新しいファイルに移動し、参照を更新する", async () => {
-		const project = new Project({
-			useInMemoryFileSystem: true,
-			manipulationSettings: {
-				indentationText: IndentationText.TwoSpaces,
-				quoteKind: QuoteKind.Double,
-			},
-			compilerOptions: { baseUrl: ".", paths: { "@/*": ["src/*"] } },
-		});
-
+		const project = createInMemoryProjectWithDoubleQuotes();
 		const oldFilePath = "/src/constants.ts";
 		const newFilePath = "/src/new-constants.ts";
-		const symbolToMove = "Color";
 		const referencingFilePath = "/src/painter.ts";
 
-		// 移動元のファイル
 		project.createSourceFile(
 			oldFilePath,
 			`export enum Color { Red, Green, Blue }
 export const DEFAULT_SIZE = 10;
 `,
 		);
-
-		// 参照元のファイル
 		project.createSourceFile(
 			referencingFilePath,
 			'import { Color } from "./constants";\nlet myColor = Color.Red;',
@@ -402,27 +288,21 @@ export const DEFAULT_SIZE = 10;
 			project,
 			oldFilePath,
 			newFilePath,
-			symbolToMove,
+			"Color",
 			SyntaxKind.EnumDeclaration,
 		);
 
-		const newSourceFile = project.getSourceFile(newFilePath);
-		const expectedNewContent = `export enum Color { Red, Green, Blue }
-`;
-		expect(newSourceFile?.getFullText()).toBe(expectedNewContent);
-
-		const updatedOldSourceFile = project.getSourceFile(oldFilePath);
-		const expectedOldContent = `export const DEFAULT_SIZE = 10;
-`;
-		expect(updatedOldSourceFile?.getFullText()).toBe(expectedOldContent);
-
-		const referencingSourceFile = project.getSourceFile(referencingFilePath);
-		const expectedReferencingContent = `import { Color } from "./new-constants";
-let myColor = Color.Red;`;
-		expect(referencingSourceFile?.getFullText()).toBe(
-			expectedReferencingContent,
+		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+			`export enum Color { Red, Green, Blue }
+`,
+		);
+		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+			`export const DEFAULT_SIZE = 10;
+`,
+		);
+		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+			`import { Color } from "./new-constants";
+let myColor = Color.Red;`,
 		);
 	});
-
-	// TODO: 他の宣言タイプ、内部依存関係、エッジケースなどのテストを追加
 });

--- a/src/ts-morph/move-symbol-to-file/move-symbol-to-file.test.ts
+++ b/src/ts-morph/move-symbol-to-file/move-symbol-to-file.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { SyntaxKind } from "ts-morph";
 import { createInMemoryProjectWithDoubleQuotes } from "../_test-utils/create-in-memory-project";
+import { getFileText } from "../_test-utils/get-file-text";
 import { moveSymbolToFile } from "./move-symbol-to-file";
 
 describe("moveSymbolToFile", () => {
@@ -31,15 +32,15 @@ console.log(myUtil());
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`export const myUtil = () => 'utility';
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export const anotherUtil = 1;
 `,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import { myUtil } from "./new-utils";
 console.log(myUtil());
 `,
@@ -82,7 +83,7 @@ console.log(symbolUsingDependency());
 			SyntaxKind.VariableStatement,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`import { dependencyFunc } from "./dependency";
 
 export const symbolUsingDependency = () => {
@@ -90,11 +91,11 @@ export const symbolUsingDependency = () => {
 };
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export const anotherInSource = true;
 `,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import { symbolUsingDependency } from "./new-location";
 console.log(symbolUsingDependency());
 `,
@@ -128,15 +129,15 @@ myFunction();
 			SyntaxKind.FunctionDeclaration,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`export function myFunction() { return 'hello'; }
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export const anotherValue = 42;
 `,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import { myFunction } from "./new-functions";
 myFunction();
 `,
@@ -170,15 +171,15 @@ const instance = new MyClass();
 			SyntaxKind.ClassDeclaration,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`export class MyClass { constructor() { console.log("Model created"); } }
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export interface AnotherInterface {}
 `,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import { MyClass } from "./new-models";
 const instance = new MyClass();
 `,
@@ -211,15 +212,15 @@ const data: MyInterface = { id: '1' };`,
 			SyntaxKind.InterfaceDeclaration,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`export interface MyInterface { id: string; }
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export type AnotherType = number;
 `,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import type { MyInterface } from "./new-types";
 const data: MyInterface = { id: '1' };`,
 		);
@@ -252,15 +253,15 @@ let value: MyType = 'test';
 			SyntaxKind.TypeAliasDeclaration,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`export type MyType = string | number;
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export const CONFIG_KEY = 'key';
 `,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import type { MyType } from "./new-aliases";
 let value: MyType = 'test';
 `,
@@ -292,15 +293,15 @@ export const DEFAULT_SIZE = 10;
 			SyntaxKind.EnumDeclaration,
 		);
 
-		expect(project.getSourceFile(newFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, newFilePath)).toBe(
 			`export enum Color { Red, Green, Blue }
 `,
 		);
-		expect(project.getSourceFile(oldFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, oldFilePath)).toBe(
 			`export const DEFAULT_SIZE = 10;
 `,
 		);
-		expect(project.getSourceFile(referencingFilePath)?.getFullText()).toBe(
+		expect(getFileText(project, referencingFilePath)).toBe(
 			`import { Color } from "./new-constants";
 let myColor = Color.Red;`,
 		);

--- a/src/ts-morph/move-symbol-to-file/remove-original-symbol.test.ts
+++ b/src/ts-morph/move-symbol-to-file/remove-original-symbol.test.ts
@@ -111,16 +111,40 @@ describe("removeOriginalSymbol", () => {
 		expect(sourceFile.getFullText().trim()).toBe(""); // 空文字列（または空白のみ）になることを期待
 	});
 
-	it("削除対象の宣言が見つからない場合 (null/undefined が渡された場合)、エラーなく完了し、ファイルは変更されない", () => {
+	it("削除対象が空配列の場合、エラーなく完了し、ファイルは変更されない", () => {
 		const project = createInMemoryProject();
 		const originalContent = "export const existing = 1;";
 		const sourceFile = project.createSourceFile(
 			"/no-change.ts",
 			originalContent,
 		);
-		const declarationsToRemove: Statement[] = [];
+
+		removeOriginalSymbol(sourceFile, []);
 
 		expect(sourceFile.getFullText()).toBe(originalContent);
+	});
+
+	it("別ファイルの宣言を渡された場合、その宣言はスキップされる", () => {
+		const project = createInMemoryProject();
+		const targetFile = project.createSourceFile(
+			"/target.ts",
+			"export const stay = 1;",
+		);
+		const otherFile = project.createSourceFile(
+			"/other.ts",
+			"export const elsewhere = 2;",
+		);
+		const elsewhereDecl = findTopLevelDeclarationByName(
+			otherFile,
+			"elsewhere",
+			SyntaxKind.VariableStatement,
+		);
+		if (!elsewhereDecl) throw new Error("Test setup failed");
+
+		removeOriginalSymbol(targetFile, [elsewhereDecl]);
+
+		expect(targetFile.getFullText()).toBe("export const stay = 1;");
+		expect(otherFile.getFullText()).toBe("export const elsewhere = 2;");
 	});
 
 	it("複数の宣言を一度に削除する", () => {

--- a/src/ts-morph/move-symbol-to-file/remove-original-symbol.test.ts
+++ b/src/ts-morph/move-symbol-to-file/remove-original-symbol.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Project, SyntaxKind } from "ts-morph";
+import { SyntaxKind } from "ts-morph";
 import type { Statement } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { removeOriginalSymbol } from "./remove-original-symbol";
 import { findTopLevelDeclarationByName } from "./find-declaration";
 
@@ -62,7 +63,7 @@ describe("removeOriginalSymbol", () => {
 			declarationSnippet,
 			assertionSnippet,
 		}) => {
-			const project = new Project({ useInMemoryFileSystem: true });
+			const project = createInMemoryProject();
 			const otherSymbolSnippet = "export const anotherSymbol = 456;";
 			const sourceFileContent = `\n${declarationSnippet}\n${otherSymbolSnippet}\n`;
 			const sourceFile = project.createSourceFile(
@@ -91,7 +92,7 @@ describe("removeOriginalSymbol", () => {
 	);
 
 	it("最後の宣言を削除した結果、ファイルが空になる", () => {
-		const project = new Project({ useInMemoryFileSystem: true });
+		const project = createInMemoryProject();
 		const symbolName = "onlySymbol";
 		const sourceFile = project.createSourceFile(
 			"/empty.ts",
@@ -111,7 +112,7 @@ describe("removeOriginalSymbol", () => {
 	});
 
 	it("削除対象の宣言が見つからない場合 (null/undefined が渡された場合)、エラーなく完了し、ファイルは変更されない", () => {
-		const project = new Project({ useInMemoryFileSystem: true });
+		const project = createInMemoryProject();
 		const originalContent = "export const existing = 1;";
 		const sourceFile = project.createSourceFile(
 			"/no-change.ts",
@@ -123,7 +124,7 @@ describe("removeOriginalSymbol", () => {
 	});
 
 	it("複数の宣言を一度に削除する", () => {
-		const project = new Project({ useInMemoryFileSystem: true });
+		const project = createInMemoryProject();
 		const content = `
 export const varToRemove = 1;
 export function funcToRemove() {}

--- a/src/ts-morph/move-symbol-to-file/update-imports-in-referencing-files.test.ts
+++ b/src/ts-morph/move-symbol-to-file/update-imports-in-referencing-files.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { Project, IndentationText, QuoteKind } from "ts-morph";
+import { IndentationText, QuoteKind } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { updateImportsInReferencingFiles } from "./update-imports-in-referencing-files";
 
 describe("updateImportsInReferencingFiles", () => {
@@ -8,33 +9,14 @@ describe("updateImportsInReferencingFiles", () => {
 	const moduleAIndexPath = `${oldDirPath}/index.ts`;
 	const newFilePath = "/src/moduleC/new-location.ts";
 
-	// --- Setup Helper Function ---
 	const setupTestProject = () => {
-		const project = new Project({
+		const project = createInMemoryProject({
 			manipulationSettings: {
 				indentationText: IndentationText.TwoSpaces,
 				quoteKind: QuoteKind.Single,
 			},
-			useInMemoryFileSystem: true,
-			compilerOptions: {
-				baseUrl: ".",
-				paths: {
-					"@/*": ["src/*"],
-				},
-				typeRoots: [],
-			},
 		});
 
-		project.createDirectory("/src");
-		project.createDirectory(oldDirPath);
-		project.createDirectory("/src/moduleB");
-		project.createDirectory("/src/moduleC");
-		project.createDirectory("/src/moduleD");
-		project.createDirectory("/src/moduleE");
-		project.createDirectory("/src/moduleF");
-		project.createDirectory("/src/moduleG");
-
-		// Use literal strings for symbols in setup
 		project.createSourceFile(
 			oldFilePath,
 			`export const exportedSymbol = 123;
@@ -201,7 +183,7 @@ let val: MyType;`;
 	});
 
 	it("移動先ファイルが元々移動元シンボルをインポートしていた場合、そのインポート指定子/宣言を削除する", async () => {
-		const project = new Project({ useInMemoryFileSystem: true });
+		const project = createInMemoryProject();
 		const oldPath = "/src/old.ts";
 		const newPath = "/src/new.ts";
 
@@ -227,7 +209,7 @@ console.log(symbolToMove, keepSymbol);`;
 		expect(referencingFile.getText()).toBe(expected);
 
 		// --- ケース2: 移動対象シンボルのみインポートしていた場合 ---
-		const project2 = new Project({ useInMemoryFileSystem: true });
+		const project2 = createInMemoryProject();
 		project2.createSourceFile(oldPath, "export const symbolToMove = 1;");
 		const referencingFile2 = project2.createSourceFile(
 			newPath,

--- a/src/ts-morph/move-symbol-to-file/update-target-file.test.ts
+++ b/src/ts-morph/move-symbol-to-file/update-target-file.test.ts
@@ -49,11 +49,15 @@ export function baz() { return qux(); }
 		expect(targetSourceFile.getFullText().trim()).toBe(expectedContent.trim());
 	});
 
-	it("requiredImportMap に自己参照パスが含まれていても、自己参照インポートは追加しない", () => {
+	it("requiredImportMap に自己参照パスが含まれていても、自己参照インポートは追加せず、既存の周囲ステートメントを保持する", () => {
 		const project = createInMemoryProject();
+		const initialContent = `export type ExistingType = number;
+
+console.log('hello');
+`;
 		const targetSourceFile = project.createSourceFile(
 			"/src/target.ts",
-			"export type ExistingType = number;\n",
+			initialContent,
 		);
 
 		updateTargetFile(
@@ -67,9 +71,7 @@ export function baz() { return qux(); }
 			[],
 		);
 
-		expect(targetSourceFile.getFullText().trim()).toBe(
-			"export type ExistingType = number;",
-		);
+		expect(targetSourceFile.getFullText().trim()).toBe(initialContent.trim());
 	});
 
 	it("既存インポートがない場合、デフォルトインポートを新規追加できる", () => {

--- a/src/ts-morph/move-symbol-to-file/update-target-file.test.ts
+++ b/src/ts-morph/move-symbol-to-file/update-target-file.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { Project } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { updateTargetFile } from "./update-target-file";
 import type { ImportMap } from "./generate-content/build-new-file-import-section";
 
 describe("updateTargetFile", () => {
 	it("既存ファイルに新しい宣言と、それに必要な新しい名前付きインポートを追加・マージできる", () => {
-		const project = new Project({ useInMemoryFileSystem: true });
+		const project = createInMemoryProject();
 		const targetFilePath = "/src/target.ts";
 		project.createSourceFile(
 			"/utils.ts",
@@ -50,7 +50,7 @@ export function baz() { return qux(); }
 	});
 
 	it("requiredImportMap に自己参照パスが含まれていても、自己参照インポートは追加しない", () => {
-		const project = new Project({ useInMemoryFileSystem: true });
+		const project = createInMemoryProject();
 		const targetFilePath = "/src/target.ts";
 		const initialContent = `export type ExistingType = number;
 

--- a/src/ts-morph/move-symbol-to-file/update-target-file.test.ts
+++ b/src/ts-morph/move-symbol-to-file/update-target-file.test.ts
@@ -51,34 +51,134 @@ export function baz() { return qux(); }
 
 	it("requiredImportMap に自己参照パスが含まれていても、自己参照インポートは追加しない", () => {
 		const project = createInMemoryProject();
-		const targetFilePath = "/src/target.ts";
-		const initialContent = `export type ExistingType = number;
-
-console.log('hello');
-`;
 		const targetSourceFile = project.createSourceFile(
-			targetFilePath,
-			initialContent,
+			"/src/target.ts",
+			"export type ExistingType = number;\n",
 		);
 
-		const requiredImportMap: ImportMap = new Map([
-			[
-				".",
-				{
-					namedImports: new Set(["ExistingType"]),
-					isNamespaceImport: false,
-				},
-			],
-		]);
+		updateTargetFile(
+			targetSourceFile,
+			new Map([
+				[
+					".",
+					{ namedImports: new Set(["ExistingType"]), isNamespaceImport: false },
+				],
+			]),
+			[],
+		);
 
-		const declarationStrings: string[] = [];
-
-		const expectedContent = initialContent;
-
-		updateTargetFile(targetSourceFile, requiredImportMap, declarationStrings);
-
-		expect(targetSourceFile.getFullText().trim()).toBe(expectedContent.trim());
+		expect(targetSourceFile.getFullText().trim()).toBe(
+			"export type ExistingType = number;",
+		);
 	});
 
-	// TODO: Add more realistic test cases (e.g., default imports, different modules)
+	it("既存インポートがない場合、デフォルトインポートを新規追加できる", () => {
+		const project = createInMemoryProject();
+		const targetSourceFile = project.createSourceFile(
+			"/src/target.ts",
+			"console.log('start');\n",
+		);
+
+		updateTargetFile(
+			targetSourceFile,
+			new Map([
+				[
+					"./logger",
+					{
+						defaultName: "logger",
+						namedImports: new Set(),
+						isNamespaceImport: false,
+					},
+				],
+			]),
+			["export const tap = () => logger.info('x');"],
+		);
+
+		expect(targetSourceFile.getFullText()).toContain(
+			'import logger from "./logger";',
+		);
+	});
+
+	it("既存インポートがない場合、名前空間インポートを新規追加できる", () => {
+		const project = createInMemoryProject();
+		const targetSourceFile = project.createSourceFile(
+			"/src/target.ts",
+			"console.log('start');\n",
+		);
+
+		updateTargetFile(
+			targetSourceFile,
+			new Map([
+				[
+					"node:path",
+					{
+						namedImports: new Set(),
+						isNamespaceImport: true,
+						namespaceImportName: "path",
+					},
+				],
+			]),
+			["export const resolve = (a: string, b: string) => path.resolve(a, b);"],
+		);
+
+		expect(targetSourceFile.getFullText()).toContain(
+			'import * as path from "node:path";',
+		);
+	});
+
+	it("既存と異なるデフォルトインポートを追加しようとした場合、既存を優先する", () => {
+		const project = createInMemoryProject();
+		const targetSourceFile = project.createSourceFile(
+			"/src/target.ts",
+			'import original from "./logger";\noriginal();\n',
+		);
+
+		updateTargetFile(
+			targetSourceFile,
+			new Map([
+				[
+					"./logger",
+					{
+						defaultName: "renamed",
+						namedImports: new Set(),
+						isNamespaceImport: false,
+					},
+				],
+			]),
+			[],
+		);
+
+		expect(targetSourceFile.getFullText()).toContain(
+			'import original from "./logger";',
+		);
+		expect(targetSourceFile.getFullText()).not.toContain("renamed");
+	});
+
+	it("名前空間インポートと通常インポートが衝突する場合、既存を優先する", () => {
+		const project = createInMemoryProject();
+		const targetSourceFile = project.createSourceFile(
+			"/src/target.ts",
+			'import { existing } from "./mod";\nexisting();\n',
+		);
+
+		updateTargetFile(
+			targetSourceFile,
+			new Map([
+				[
+					"./mod",
+					{
+						namedImports: new Set(),
+						isNamespaceImport: true,
+						namespaceImportName: "mod",
+					},
+				],
+			]),
+			[],
+		);
+
+		expect(targetSourceFile.getFullText()).toContain(
+			'import { existing } from "./mod";',
+		);
+		expect(targetSourceFile.getFullText()).not.toContain("import * as mod");
+	});
 });

--- a/src/ts-morph/rename-file-system/_utils/get-identifier-node-from-declaration.test.ts
+++ b/src/ts-morph/rename-file-system/_utils/get-identifier-node-from-declaration.test.ts
@@ -135,4 +135,30 @@ describe("getIdentifierNodeFromDeclaration", () => {
 			}
 		},
 	);
+
+	it("Identifier ノード自体を渡された場合はそのまま返す (フォールバック1)", () => {
+		const sf = project.createSourceFile(
+			"/fallback-identifier.ts",
+			"const foo = 1;",
+		);
+		const identifier = sf
+			.getVariableStatements()[0]
+			.getDeclarations()[0]
+			.getNameNode();
+
+		expect(getIdentifierNodeFromDeclaration(identifier)?.getText()).toBe("foo");
+	});
+
+	it("getNameNode を持つ ExportSpecifier から識別子を取得できる (フォールバック2)", () => {
+		const sf = project.createSourceFile(
+			"/fallback-export-specifier.ts",
+			"const foo = 1;\nexport { foo as bar };",
+		);
+		const exportDecl = sf.getExportDeclarations()[0];
+		const exportSpecifier = exportDecl.getNamedExports()[0];
+
+		expect(getIdentifierNodeFromDeclaration(exportSpecifier)?.getText()).toBe(
+			"foo",
+		);
+	});
 });

--- a/src/ts-morph/rename-file-system/_utils/skip-ts-morph-ref-update.test.ts
+++ b/src/ts-morph/rename-file-system/_utils/skip-ts-morph-ref-update.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { createInMemoryProject } from "../../_test-utils/create-in-memory-project";
+import { withSkippedTsMorphReferenceUpdates } from "./skip-ts-morph-ref-update";
+
+vi.mock("../../../utils/logger");
+
+describe("withSkippedTsMorphReferenceUpdates", () => {
+	it("通常の Project では fn が実行され、prototype がパッチ後に復元される", () => {
+		const project = createInMemoryProject();
+		const sf = project.createSourceFile("/src/a.ts", "export const a = 1;");
+		const proto = Object.getPrototypeOf(sf) as Record<string, unknown>;
+		const originalGet = proto._getReferencesForMoveInternal;
+		const originalUpdate = proto._updateReferencesForMoveInternal;
+
+		const result = withSkippedTsMorphReferenceUpdates(project, () => {
+			expect(proto._getReferencesForMoveInternal).not.toBe(originalGet);
+			expect(proto._updateReferencesForMoveInternal).not.toBe(originalUpdate);
+			return 42;
+		});
+
+		expect(result).toBe(42);
+		expect(proto._getReferencesForMoveInternal).toBe(originalGet);
+		expect(proto._updateReferencesForMoveInternal).toBe(originalUpdate);
+	});
+
+	it("fn が throw した場合でも prototype は復元される", () => {
+		const project = createInMemoryProject();
+		const sf = project.createSourceFile("/src/a.ts", "export const a = 1;");
+		const proto = Object.getPrototypeOf(sf) as Record<string, unknown>;
+		const originalGet = proto._getReferencesForMoveInternal;
+		const originalUpdate = proto._updateReferencesForMoveInternal;
+
+		expect(() =>
+			withSkippedTsMorphReferenceUpdates(project, () => {
+				throw new Error("boom");
+			}),
+		).toThrow("boom");
+
+		expect(proto._getReferencesForMoveInternal).toBe(originalGet);
+		expect(proto._updateReferencesForMoveInternal).toBe(originalUpdate);
+	});
+
+	it("Project に SourceFile が 1 つもない場合、fn はそのまま実行される (fallback)", () => {
+		const project = createInMemoryProject();
+		const result = withSkippedTsMorphReferenceUpdates(project, () => "ok");
+		expect(result).toBe("ok");
+	});
+
+	it("prototype の私的 API が見つからない場合も fn はそのまま実行される (fallback)", () => {
+		const project = createInMemoryProject();
+		const sf = project.createSourceFile("/src/a.ts", "export const a = 1;");
+		const proto = Object.getPrototypeOf(sf) as Record<string, unknown>;
+		const originalGet = proto._getReferencesForMoveInternal;
+		const originalUpdate = proto._updateReferencesForMoveInternal;
+
+		// private API を一時的に非関数に差し替える
+		proto._getReferencesForMoveInternal = undefined;
+		proto._updateReferencesForMoveInternal = undefined;
+
+		try {
+			const result = withSkippedTsMorphReferenceUpdates(project, () => "ok");
+			expect(result).toBe("ok");
+		} finally {
+			proto._getReferencesForMoveInternal = originalGet;
+			proto._updateReferencesForMoveInternal = originalUpdate;
+		}
+	});
+});

--- a/src/ts-morph/rename-file-system/cleanup-empty-old-directories.test.ts
+++ b/src/ts-morph/rename-file-system/cleanup-empty-old-directories.test.ts
@@ -53,7 +53,8 @@ describe("cleanupEmptyOldDirectories", () => {
 		const project = createInMemoryProject();
 		project.createSourceFile("/src/old/a.ts", "export const a = 1;");
 		const controller = new AbortController();
-		controller.abort();
+		const abortReason = new Error("test-abort");
+		controller.abort(abortReason);
 
 		expect(() =>
 			cleanupEmptyOldDirectories(
@@ -61,6 +62,6 @@ describe("cleanupEmptyOldDirectories", () => {
 				[{ oldPath: "/src/old", newPath: "/src/new" }],
 				controller.signal,
 			),
-		).toThrow();
+		).toThrow(abortReason);
 	});
 });

--- a/src/ts-morph/rename-file-system/cleanup-empty-old-directories.test.ts
+++ b/src/ts-morph/rename-file-system/cleanup-empty-old-directories.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import { cleanupEmptyOldDirectories } from "./cleanup-empty-old-directories";
+
+vi.mock("../../utils/logger");
+
+describe("cleanupEmptyOldDirectories", () => {
+	it("空のディレクトリが残っている場合、削除する", () => {
+		const project = createInMemoryProject();
+		const fs = project.getFileSystem();
+		const sf = project.createSourceFile("/src/old/a.ts", "export const a = 1;");
+		project.saveSync();
+		sf.deleteImmediatelySync();
+
+		cleanupEmptyOldDirectories(project, [
+			{ oldPath: "/src/old", newPath: "/src/new" },
+		]);
+
+		expect(fs.directoryExistsSync("/src/old")).toBe(false);
+	});
+
+	it("untracked ファイルが残っているディレクトリは削除しない", () => {
+		const project = createInMemoryProject();
+		const fs = project.getFileSystem();
+		const sf = project.createSourceFile("/src/old/a.ts", "export const a = 1;");
+		project.saveSync();
+		sf.deleteImmediatelySync();
+		fs.writeFileSync("/src/old/README.md", "stay");
+
+		cleanupEmptyOldDirectories(project, [
+			{ oldPath: "/src/old", newPath: "/src/new" },
+		]);
+
+		expect(fs.directoryExistsSync("/src/old")).toBe(true);
+		expect(fs.readFileSync("/src/old/README.md")).toBe("stay");
+	});
+
+	it("directoryRenames が空の場合、何もしない", () => {
+		const project = createInMemoryProject();
+		expect(() => cleanupEmptyOldDirectories(project, [])).not.toThrow();
+	});
+
+	it("旧ディレクトリが既に存在しない場合、何もしない (forget のみ)", () => {
+		const project = createInMemoryProject();
+		// project tree に存在しないディレクトリ
+		cleanupEmptyOldDirectories(project, [
+			{ oldPath: "/src/nonexistent", newPath: "/src/new" },
+		]);
+		// throw しなければOK
+	});
+
+	it("AbortSignal で中断できる", () => {
+		const project = createInMemoryProject();
+		project.createSourceFile("/src/old/a.ts", "export const a = 1;");
+		const controller = new AbortController();
+		controller.abort();
+
+		expect(() =>
+			cleanupEmptyOldDirectories(
+				project,
+				[{ oldPath: "/src/old", newPath: "/src/new" }],
+				controller.signal,
+			),
+		).toThrow();
+	});
+});

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.base.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.base.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import * as path from "node:path";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import { expectFileMoved } from "../_test-utils/expect-file-moved";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
+import { getFileText } from "../_test-utils/get-file-text";
 
 describe("renameFileSystemEntry Base Cases", () => {
 	it("ファイルリネーム時に相対パスとエイリアスパスのimport文を正しく更新する", async () => {
@@ -32,9 +34,7 @@ console.log(relativeImport(), aliasImport(), indexImport());
 			dryRun: false,
 		});
 
-		const updatedComponentContent = project
-			.getSourceFileOrThrow(componentPath)
-			.getFullText();
+		const updatedComponentContent = getFileText(project, componentPath);
 
 		expect(updatedComponentContent).toBe(
 			`import { oldUtil as relativeImport } from '../utils/new-util';
@@ -44,8 +44,7 @@ import { oldUtil as indexImport } from '../utils';
 console.log(relativeImport(), aliasImport(), indexImport());
 `,
 		);
-		expect(project.getSourceFile(oldUtilPath)).toBeUndefined();
-		expect(project.getSourceFile(newUtilPath)).toBeDefined();
+		expectFileMoved(project, oldUtilPath, newUtilPath);
 	});
 
 	it("フォルダリネーム時に相対パスとエイリアスパスのimport文を正しく更新する", async () => {
@@ -77,9 +76,7 @@ console.log(relativeImport(), aliasImport(), indexImport());
 			dryRun: false,
 		});
 
-		const updatedComponentContent = project
-			.getSourceFileOrThrow(componentPath)
-			.getFullText();
+		const updatedComponentContent = getFileText(project, componentPath);
 		expect(
 			updatedComponentContent,
 		).toBe(`import { feature as relativeImport } from '../new-feature/feature';
@@ -134,12 +131,8 @@ console.log(valA2);
 			dryRun: false,
 		});
 
-		const updatedFileBContent = project
-			.getSourceFileOrThrow(fileBPath)
-			.getFullText();
-		const updatedFileA3Content = project
-			.getSourceFileOrThrow(fileA3Path)
-			.getFullText();
+		const updatedFileBContent = getFileText(project, fileBPath);
+		const updatedFileA3Content = getFileText(project, fileA3Path);
 
 		expect(updatedFileBContent).toContain(
 			"import { valA2 } from '../dirA/renamedA2';",
@@ -151,8 +144,7 @@ console.log(valA2);
 			"import { valA2 } from './renamedA2';",
 		);
 
-		expect(project.getSourceFile(fileA2Path)).toBeUndefined();
-		expect(project.getSourceFile(newFileA2Path)).toBeDefined();
+		expectFileMoved(project, fileA2Path, newFileA2Path);
 	});
 
 	it("親階層(..)への相対パスimport文を持つファイルを、別のディレクトリに移動（リネーム）した際に、参照元のパスが正しく更新される", async () => {
@@ -180,14 +172,11 @@ console.log(valA1);
 			dryRun: false,
 		});
 
-		const updatedFileA2Content = project
-			.getSourceFileOrThrow(fileA2Path)
-			.getFullText();
+		const updatedFileA2Content = getFileText(project, fileA2Path);
 		expect(updatedFileA2Content).toContain(
 			"import { valA1 } from '../dirC/movedA1';",
 		);
 
-		expect(project.getSourceFile(fileA1Path)).toBeUndefined();
-		expect(project.getSourceFile(newFileA1Path)).toBeDefined();
+		expectFileMoved(project, fileA1Path, newFileA1Path);
 	});
 });

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.base.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.base.test.ts
@@ -1,42 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { Project } from "ts-morph";
 import * as path from "node:path";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
-
-// --- Test Setup Helper ---
-
-const setupProject = () => {
-	const project = new Project({
-		useInMemoryFileSystem: true,
-		compilerOptions: {
-			baseUrl: ".",
-			paths: {
-				"@/*": ["src/*"],
-			},
-			esModuleInterop: true,
-			allowJs: true,
-		},
-	});
-
-	// 共通のディレクトリ構造をメモリ上に作成
-	project.createDirectory("/src");
-	project.createDirectory("/src/utils");
-	project.createDirectory("/src/components");
-	project.createDirectory("/src/old-feature");
-	project.createDirectory("/src/myFeature");
-	project.createDirectory("/src/anotherFeature");
-	project.createDirectory("/src/dirA");
-	project.createDirectory("/src/dirB");
-	project.createDirectory("/src/dirC");
-	project.createDirectory("/src/core");
-	project.createDirectory("/src/widgets");
-
-	return project;
-};
 
 describe("renameFileSystemEntry Base Cases", () => {
 	it("ファイルリネーム時に相対パスとエイリアスパスのimport文を正しく更新する", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldUtilPath = "/src/utils/old-util.ts";
 		const newUtilPath = "/src/utils/new-util.ts";
 		const componentPath = "/src/components/MyComponent.ts";
@@ -80,7 +49,7 @@ console.log(relativeImport(), aliasImport(), indexImport());
 	});
 
 	it("フォルダリネーム時に相対パスとエイリアスパスのimport文を正しく更新する", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldFeatureDir = "/src/old-feature";
 		const newFeatureDir = "/src/new-feature";
 		const featureFilePath = path.join(oldFeatureDir, "feature.ts");
@@ -130,7 +99,7 @@ console.log(relativeImport(), aliasImport(), indexImport());
 	});
 
 	it("同階層(.)や親階層(..)への相対パスimport文を持つファイルをリネームした際に、参照元のパスが正しく更新される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const dirA = "/src/dirA";
 		const dirB = "/src/dirB";
 
@@ -187,7 +156,7 @@ console.log(valA2);
 	});
 
 	it("親階層(..)への相対パスimport文を持つファイルを、別のディレクトリに移動（リネーム）した際に、参照元のパスが正しく更新される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const dirA = "/src/dirA";
 		const dirC = "/src/dirC";
 

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.complex.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.complex.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import * as path from "node:path";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import { expectFileMoved } from "../_test-utils/expect-file-moved";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
+import { getFileText } from "../_test-utils/get-file-text";
 
 describe("renameFileSystemEntry Complex Cases", () => {
 	it("内部参照を持つフォルダをリネームする", async () => {
@@ -55,11 +57,9 @@ describe("renameFileSystemEntry Complex Cases", () => {
 			dryRun: false,
 		});
 
-		expect(project.getSourceFile(oldFile1)).toBeUndefined();
-		expect(project.getSourceFile(newFile1)).toBeDefined();
-		expect(project.getSourceFile(oldFile2)).toBeUndefined();
-		expect(project.getSourceFile(newFile2)).toBeDefined();
-		const updatedRef = project.getSourceFileOrThrow(refFile).getFullText();
+		expectFileMoved(project, oldFile1, newFile1);
+		expectFileMoved(project, oldFile2, newFile2);
+		const updatedRef = getFileText(project, refFile);
 		expect(updatedRef).toContain("import { val1 } from './utils/renamed1';");
 		expect(updatedRef).toContain(
 			"import { val2 } from './components/renamed2';",
@@ -91,11 +91,10 @@ describe("renameFileSystemEntry Complex Cases", () => {
 			dryRun: false,
 		});
 
-		expect(project.getSourceFile(oldFile)).toBeUndefined();
-		expect(project.getSourceFile(newFile)).toBeDefined();
+		expectFileMoved(project, oldFile, newFile);
 		expect(project.getDirectory(newDir)).toBeDefined();
 		expect(project.getSourceFile(path.join(newDir, "comp.ts"))).toBeDefined();
-		const updatedRef = project.getSourceFileOrThrow(refFile).getFullText();
+		const updatedRef = getFileText(project, refFile);
 		expect(updatedRef).toContain("import { valA } from './utils/fileRenamed';");
 		expect(updatedRef).toContain("import { valComp } from './widgets/comp';");
 	});
@@ -199,13 +198,9 @@ describe("renameFileSystemEntry Complex Cases", () => {
 		});
 
 		expect(project.getSourceFile(tempFile)).toBeUndefined();
-		expect(project.getSourceFile(fileA)?.getFullText()).toContain(
-			"export const valB = 'B';",
-		);
-		expect(project.getSourceFile(fileB)?.getFullText()).toContain(
-			"export const valA = 'A';",
-		);
-		const updatedRef = project.getSourceFileOrThrow(refFile).getFullText();
+		expect(getFileText(project, fileA)).toContain("export const valB = 'B';");
+		expect(getFileText(project, fileB)).toContain("export const valA = 'A';");
+		const updatedRef = getFileText(project, refFile);
 		expect(updatedRef).toContain("import { valA } from './fileB';");
 		expect(updatedRef).toContain("import { valB } from './fileA';");
 	});

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.complex.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.complex.test.ts
@@ -1,34 +1,11 @@
 import { describe, it, expect } from "vitest";
 import * as path from "node:path";
-import { Project } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
-
-// --- Test Setup Helper ---
-
-const setupProject = () => {
-	const project = new Project({
-		useInMemoryFileSystem: true,
-		compilerOptions: {
-			baseUrl: ".",
-			paths: {
-				"@/*": ["src/*"],
-			},
-			esModuleInterop: true,
-			allowJs: true,
-		},
-	});
-
-	project.createDirectory("/src");
-	project.createDirectory("/src/utils");
-	project.createDirectory("/src/components");
-	project.createDirectory("/src/internal-feature");
-
-	return project;
-};
 
 describe("renameFileSystemEntry Complex Cases", () => {
 	it("内部参照を持つフォルダをリネームする", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldDirPath = "/src/internal-feature";
 		const newDirPath = "/src/cool-feature";
 		const file1Path = path.join(oldDirPath, "file1.ts");
@@ -55,7 +32,7 @@ describe("renameFileSystemEntry Complex Cases", () => {
 	});
 
 	it("複数のファイルを同時にリネームし、それぞれの参照が正しく更新される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldFile1 = "/src/utils/file1.ts";
 		const newFile1 = "/src/utils/renamed1.ts";
 		const oldFile2 = "/src/components/file2.ts";
@@ -90,7 +67,7 @@ describe("renameFileSystemEntry Complex Cases", () => {
 	});
 
 	it("ファイルとディレクトリを同時にリネームし、それぞれの参照が正しく更新される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldFile = "/src/utils/fileA.ts";
 		const newFile = "/src/utils/fileRenamed.ts";
 		const oldDir = "/src/components";
@@ -124,7 +101,7 @@ describe("renameFileSystemEntry Complex Cases", () => {
 	});
 
 	it("ディレクトリ rename 後、旧ディレクトリ階層の空サブディレクトリが残らない (issue #27)", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldDirPath = "/src/foo";
 		const newDirPath = "/src/bar";
 
@@ -163,7 +140,7 @@ describe("renameFileSystemEntry Complex Cases", () => {
 		// shell の `mv` と同じく untracked / 想定外ファイルも全部 new dir に運ばれる。
 		// 注意: src/ 配下に手書き README や generated dist/ を置いている等のケースで
 		// 挙動が変わるため、利用側はそれを想定したディレクトリ構成にすること。
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldDirPath = "/src/foo";
 		const newDirPath = "/src/bar";
 
@@ -192,7 +169,7 @@ describe("renameFileSystemEntry Complex Cases", () => {
 	});
 
 	it("ファイル名をスワップする（一時ファイル経由）", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const fileA = "/src/fileA.ts";
 		const fileB = "/src/fileB.ts";
 		const tempFile = "/src/temp.ts";

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.errors.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.errors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
+import { getFileText } from "../_test-utils/get-file-text";
 
 function setupProjectWithExistingDir() {
 	const project = createInMemoryProject();
@@ -58,9 +59,7 @@ describe("renameFileSystemEntry Error Cases", () => {
 			/^Rename process failed: リネーム先パスに既にファイルが存在します.*See logs for details.$/,
 		);
 		expect(project.getSourceFile(oldPath)).toBeDefined();
-		expect(project.getSourceFile(existingPath)?.getFullText()).toContain(
-			"existing = true",
-		);
+		expect(getFileText(project, existingPath)).toContain("existing = true");
 	});
 
 	it("リネーム先のパスに既にディレクトリが存在する場合、エラーをスローする", async () => {

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.errors.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.errors.test.ts
@@ -1,33 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { Project } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
 
-// --- Test Setup Helper ---
-
-const setupProject = () => {
-	const project = new Project({
-		useInMemoryFileSystem: true,
-		compilerOptions: {
-			baseUrl: ".",
-			paths: {
-				"@/*": ["src/*"],
-			},
-			esModuleInterop: true,
-			allowJs: true,
-		},
-	});
-
-	project.createDirectory("/src");
-	project.createDirectory("/src/utils");
-	project.createDirectory("/src/components");
+function setupProjectWithExistingDir() {
+	const project = createInMemoryProject();
 	project.createDirectory("/src/existing-dir");
-
 	return project;
-};
+}
 
 describe("renameFileSystemEntry Error Cases", () => {
 	it("存在しないファイルをリネームしようとするとエラーをスローする", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldPath = "/src/nonexistent.ts";
 		const newPath = "/src/new.ts";
 
@@ -43,7 +26,7 @@ describe("renameFileSystemEntry Error Cases", () => {
 	});
 
 	it("存在しないディレクトリをリネームしようとするとエラーをスローする", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldPath = "/src/nonexistent-dir";
 		const newPath = "/src/new-dir";
 
@@ -59,7 +42,7 @@ describe("renameFileSystemEntry Error Cases", () => {
 	});
 
 	it("リネーム先のパスに既にファイルが存在する場合、エラーをスローする (上書きしない)", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldPath = "/src/file1.ts";
 		const existingPath = "/src/existing.ts";
 		project.createSourceFile(oldPath, "export const file1 = 1;");
@@ -81,7 +64,7 @@ describe("renameFileSystemEntry Error Cases", () => {
 	});
 
 	it("リネーム先のパスに既にディレクトリが存在する場合、エラーをスローする", async () => {
-		const project = setupProject();
+		const project = setupProjectWithExistingDir();
 		const oldPath = "/src/file1.ts";
 		const existingDirPath = "/src/existing-dir";
 		project.createSourceFile(oldPath, "export const file1 = 1;");
@@ -100,7 +83,7 @@ describe("renameFileSystemEntry Error Cases", () => {
 	});
 
 	it("リネーム先のパスが重複する場合、エラーをスローする", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const file1 = "/src/file1.ts";
 		const file2 = "/src/file2.ts";
 		const sameNewPath = "/src/renamed.ts";

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.index.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.index.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import * as path from "node:path";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import { expectFileMoved } from "../_test-utils/expect-file-moved";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
+import { getFileText } from "../_test-utils/get-file-text";
 
 describe("renameFileSystemEntry Index File Cases", () => {
 	it("index.ts ファイル自体をリネームする", async () => {
@@ -22,8 +24,7 @@ describe("renameFileSystemEntry Index File Cases", () => {
 			dryRun: false,
 		});
 
-		expect(project.getSourceFile(oldIndexPath)).toBeUndefined();
-		expect(project.getSourceFile(newIndexPath)).toBeDefined();
+		expectFileMoved(project, oldIndexPath, newIndexPath);
 		const updatedComponent = project.getSourceFileOrThrow(componentPath);
 		// index.ts をリネームした場合、ディレクトリ参照はリネーム後のファイル名になるべき
 		expect(updatedComponent.getFullText()).toContain(
@@ -91,11 +92,8 @@ describe("renameFileSystemEntry Index File Cases", () => {
 			dryRun: false,
 		});
 
-		const updatedImporterContent = project
-			.getSourceFileOrThrow(importerPath)
-			.getFullText();
-		expect(project.getSourceFile(oldIndexPath)).toBeUndefined();
-		expect(project.getSourceFile(newIndexPath)).toBeDefined();
+		const updatedImporterContent = getFileText(project, importerPath);
+		expectFileMoved(project, oldIndexPath, newIndexPath);
 		// パスエイリアス参照がリネーム後のファイルパスに更新されることを期待。
 		expect(updatedImporterContent).toContain(
 			"import MyFeature from './myFeature/mainComponent';",
@@ -124,11 +122,8 @@ describe("renameFileSystemEntry Index File Cases", () => {
 			dryRun: false,
 		});
 
-		const updatedImporterContent = project
-			.getSourceFileOrThrow(importerPath)
-			.getFullText();
-		expect(project.getSourceFile(oldIndexPath)).toBeUndefined();
-		expect(project.getSourceFile(newIndexPath)).toBeDefined();
+		const updatedImporterContent = getFileText(project, importerPath);
+		expectFileMoved(project, oldIndexPath, newIndexPath);
 		// パスエイリアス参照がリネーム後のファイルパスに更新されることを期待。
 		expect(updatedImporterContent).toContain(
 			"import CoreFunc from './anotherFeature/coreFunction';",

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.index.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.index.test.ts
@@ -1,38 +1,11 @@
 import { describe, it, expect } from "vitest";
 import * as path from "node:path";
-import { Project } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
-
-// --- Test Setup Helper ---
-
-const setupProject = () => {
-	const project = new Project({
-		useInMemoryFileSystem: true,
-		compilerOptions: {
-			baseUrl: ".",
-			paths: {
-				"@/*": ["src/*"],
-			},
-			esModuleInterop: true,
-			allowJs: true,
-		},
-	});
-
-	// 共通のディレクトリ構造をメモリ上に作成
-	project.createDirectory("/src");
-	project.createDirectory("/src/utils");
-	project.createDirectory("/src/components");
-	project.createDirectory("/src/myFeature");
-	project.createDirectory("/src/anotherFeature");
-	project.createDirectory("/src/featureA");
-	project.createDirectory("/src/core");
-
-	return project;
-};
 
 describe("renameFileSystemEntry Index File Cases", () => {
 	it("index.ts ファイル自体をリネームする", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldIndexPath = "/src/utils/index.ts";
 		const newIndexPath = "/src/utils/main.ts";
 		const componentPath = "/src/components/MyComponent.ts";
@@ -59,7 +32,7 @@ describe("renameFileSystemEntry Index File Cases", () => {
 	});
 
 	it("ディレクトリリネーム時に、内部からの '.' や外部からの '..' による index.ts 参照が正しく更新される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldDirPath = "/src/featureA";
 		const newDirPath = "/src/featureRenamed";
 		const indexTsPath = path.join(oldDirPath, "index.ts");
@@ -97,7 +70,7 @@ describe("renameFileSystemEntry Index File Cases", () => {
 	});
 
 	it("index.ts でデフォルトエクスポートされた変数をパスエイリアス付きディレクトリ名でインポートしている場合、index.ts リネーム時にパスが正しく更新される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const featureDir = "/src/myFeature";
 		const oldIndexPath = path.join(featureDir, "index.ts");
 		const newIndexPath = path.join(featureDir, "mainComponent.ts");
@@ -130,7 +103,7 @@ describe("renameFileSystemEntry Index File Cases", () => {
 	});
 
 	it("index.ts でデフォルトエクスポートされた関数をパスエイリアス付きディレクトリ名でインポートしている場合、index.ts リネーム時にパスが正しく更新される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const featureDir = "/src/anotherFeature";
 		const oldIndexPath = path.join(featureDir, "index.ts");
 		const newIndexPath = path.join(featureDir, "coreFunction.ts");

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import { expectFileMoved } from "../_test-utils/expect-file-moved";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
+import { getFileText } from "../_test-utils/get-file-text";
 
 describe("renameFileSystemEntry Special Cases", () => {
 	it("dryRun: true の場合、ファイルシステム（メモリ上）の変更を行わず、変更予定リストを返す", async () => {
@@ -24,8 +26,7 @@ describe("renameFileSystemEntry Special Cases", () => {
 			dryRun: true,
 		});
 
-		expect(project.getSourceFile(oldUtilPath)).toBeUndefined();
-		expect(project.getSourceFile(newUtilPath)).toBeDefined();
+		expectFileMoved(project, oldUtilPath, newUtilPath);
 
 		expect(result.changedFiles).toContain(newUtilPath);
 		expect(result.changedFiles).toContain(componentPath);
@@ -44,9 +45,8 @@ describe("renameFileSystemEntry Special Cases", () => {
 			dryRun: false,
 		});
 
-		expect(project.getSourceFile(oldPath)).toBeUndefined();
-		expect(project.getSourceFile(newPath)).toBeDefined();
-		expect(project.getSourceFileOrThrow(newPath).getFullText()).toContain(
+		expectFileMoved(project, oldPath, newPath);
+		expect(getFileText(project, newPath)).toContain(
 			"export const lonely = true;",
 		);
 		expect(result.changedFiles).toEqual([newPath]);
@@ -73,11 +73,8 @@ describe("renameFileSystemEntry Special Cases", () => {
 			dryRun: false,
 		});
 
-		const updatedImporterContent = project
-			.getSourceFileOrThrow(importerPath)
-			.getFullText();
-		expect(project.getSourceFile(oldDefaultPath)).toBeUndefined();
-		expect(project.getSourceFile(newDefaultPath)).toBeDefined();
+		const updatedImporterContent = getFileText(project, importerPath);
+		expectFileMoved(project, oldDefaultPath, newDefaultPath);
 		expect(updatedImporterContent).toContain(
 			"import MyDefaultImport from './utils/renamedDefaultExport';",
 		);
@@ -104,11 +101,8 @@ describe("renameFileSystemEntry Special Cases", () => {
 			dryRun: false,
 		});
 
-		const updatedImporterContent = project
-			.getSourceFileOrThrow(importerPath)
-			.getFullText();
-		expect(project.getSourceFile(oldVarDefaultPath)).toBeUndefined();
-		expect(project.getSourceFile(newVarDefaultPath)).toBeDefined();
+		const updatedImporterContent = getFileText(project, importerPath);
+		expectFileMoved(project, oldVarDefaultPath, newVarDefaultPath);
 		expect(updatedImporterContent).toContain(
 			"import MyVarImport from './utils/renamedVariableDefaultExport';",
 		);
@@ -144,9 +138,7 @@ console.log(legacyValue, helperValue);
 			dryRun: false,
 		});
 
-		const updatedImporterContent = project
-			.getSourceFileOrThrow(importerPath)
-			.getFullText();
+		const updatedImporterContent = getFileText(project, importerPath);
 
 		expect(updatedImporterContent).toContain(
 			"import { legacyValue } from '../utils/modern-util.js';",
@@ -155,10 +147,8 @@ console.log(legacyValue, helperValue);
 			"import { helperValue } from '../utils/renamed-helper';",
 		);
 
-		expect(project.getSourceFile(oldJsPath)).toBeUndefined();
-		expect(project.getSourceFile(newJsPath)).toBeDefined();
-		expect(project.getSourceFile(otherTsPath)).toBeUndefined();
-		expect(project.getSourceFile(newOtherTsPath)).toBeDefined();
+		expectFileMoved(project, oldJsPath, newJsPath);
+		expectFileMoved(project, otherTsPath, newOtherTsPath);
 	});
 });
 
@@ -187,21 +177,16 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 			dryRun: false,
 		});
 
-		expect(project.getSourceFile(moduleBOriginalPath)).toBeUndefined();
-		expect(project.getSourceFile(moduleBRenamedPath)).toBeDefined();
-		expect(project.getSourceFileOrThrow(moduleBRenamedPath).getFullText()).toBe(
+		expectFileMoved(project, moduleBOriginalPath, moduleBRenamedPath);
+		expect(getFileText(project, moduleBRenamedPath)).toBe(
 			"export const importantValue = 'Hello from B';",
 		);
 
-		const indexTsContent = project
-			.getSourceFileOrThrow(indexTsPath)
-			.getFullText();
+		const indexTsContent = getFileText(project, indexTsPath);
 		expect(indexTsContent).toContain('export * from "./moduleBRenamed";');
 		expect(indexTsContent).not.toContain('export * from "./moduleB";');
 
-		const componentContent = project
-			.getSourceFileOrThrow(componentPath)
-			.getFullText();
+		const componentContent = getFileText(project, componentPath);
 		expect(componentContent).toContain(
 			"import { importantValue } from '@/utils';",
 		);
@@ -239,15 +224,12 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 			dryRun: false,
 		});
 
-		expect(project.getSourceFile(moduleCOriginalPath)).toBeUndefined();
-		expect(project.getSourceFile(moduleCRenamedPath)).toBeDefined();
-		expect(project.getSourceFileOrThrow(moduleCRenamedPath).getFullText()).toBe(
+		expectFileMoved(project, moduleCOriginalPath, moduleCRenamedPath);
+		expect(getFileText(project, moduleCRenamedPath)).toBe(
 			"export const specificExport = 'Hello from C';",
 		);
 
-		const indexTsContent = project
-			.getSourceFileOrThrow(indexTsPath)
-			.getFullText();
+		const indexTsContent = getFileText(project, indexTsPath);
 		expect(indexTsContent).toContain(
 			'export { specificExport } from "./moduleCRenamed";',
 		);
@@ -255,9 +237,7 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 			'export { specificExport } from "./moduleC";',
 		);
 
-		const componentContent = project
-			.getSourceFileOrThrow(componentPath)
-			.getFullText();
+		const componentContent = getFileText(project, componentPath);
 		expect(componentContent).toContain(
 			"import { specificExport } from '@/utils';",
 		);
@@ -304,16 +284,14 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 		expect(project.getSourceFile(moduleDRenamedPath)).toBeDefined();
 		expect(project.getSourceFile(indexTsRenamedPath)).toBeDefined();
 
-		expect(project.getSourceFileOrThrow(moduleDRenamedPath).getFullText()).toBe(
+		expect(getFileText(project, moduleDRenamedPath)).toBe(
 			"export const valueFromD = 'Hello from D';",
 		);
-		expect(project.getSourceFileOrThrow(indexTsRenamedPath).getFullText()).toBe(
+		expect(getFileText(project, indexTsRenamedPath)).toBe(
 			'export * from "./moduleD";',
 		);
 
-		const componentContent = project
-			.getSourceFileOrThrow(componentPath)
-			.getFullText();
+		const componentContent = getFileText(project, componentPath);
 		expect(componentContent).toContain(
 			"import { valueFromD } from '../newUtils/index';",
 		);
@@ -357,9 +335,7 @@ export const b: CreateRequest = { id: "y" };
 			dryRun: false,
 		});
 
-		const updatedUsageContent = project
-			.getSourceFileOrThrow(usagePath)
-			.getFullText();
+		const updatedUsageContent = getFileText(project, usagePath);
 
 		// 旧パスは namespace import (A) / named import (B) 両方から消えていること
 		expect(updatedUsageContent).not.toContain("@/types/request");
@@ -397,9 +373,7 @@ export const a: Req.CreateRequest = { id: "x" };
 			dryRun: false,
 		});
 
-		const updatedUsageContent = project
-			.getSourceFileOrThrow(usagePath)
-			.getFullText();
+		const updatedUsageContent = getFileText(project, usagePath);
 
 		expect(updatedUsageContent).not.toContain("./types/request");
 		expect(updatedUsageContent).toContain(
@@ -432,9 +406,7 @@ describe("renameFileSystemEntry with index.ts re-exports (actual bug reproductio
 			"import { funcA, funcB } from '@/utils';\nconsole.log(funcA(), funcB());",
 		);
 
-		const originalComponentContent = project
-			.getSourceFileOrThrow(componentPath)
-			.getFullText();
+		const originalComponentContent = getFileText(project, componentPath);
 
 		await renameFileSystemEntry({
 			project,
@@ -443,24 +415,19 @@ describe("renameFileSystemEntry with index.ts re-exports (actual bug reproductio
 		});
 
 		// 1. moduleA.ts がリネームされていること
-		expect(project.getSourceFile(moduleAOriginalPath)).toBeUndefined();
-		expect(project.getSourceFile(moduleARenamedPath)).toBeDefined();
-		expect(project.getSourceFileOrThrow(moduleARenamedPath).getFullText()).toBe(
+		expectFileMoved(project, moduleAOriginalPath, moduleARenamedPath);
+		expect(getFileText(project, moduleARenamedPath)).toBe(
 			"export const funcA = () => 'original_A';",
 		);
 
 		// 2. index.ts が正しく更新されていること
-		const indexTsContent = project
-			.getSourceFileOrThrow(indexTsPath)
-			.getFullText();
+		const indexTsContent = getFileText(project, indexTsPath);
 		expect(indexTsContent).toContain('export * from "./moduleARenamed";');
 		expect(indexTsContent).toContain('export * from "./moduleB";');
 		expect(indexTsContent).not.toContain('export * from "./moduleA";');
 
 		// 3. MyComponent.ts のインポートパスが変更されていないこと
-		const updatedComponentContent = project
-			.getSourceFileOrThrow(componentPath)
-			.getFullText();
+		const updatedComponentContent = getFileText(project, componentPath);
 		expect(updatedComponentContent).toBe(originalComponentContent);
 		// さらに具体的に確認
 		expect(updatedComponentContent).toContain(

--- a/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
+++ b/src/ts-morph/rename-file-system/rename-file-system-entry.special.test.ts
@@ -1,32 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { Project } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { renameFileSystemEntry } from "./rename-file-system-entry";
-
-// --- Test Setup Helper ---
-
-const setupProject = () => {
-	const project = new Project({
-		useInMemoryFileSystem: true,
-		compilerOptions: {
-			baseUrl: ".",
-			paths: {
-				"@/*": ["src/*"],
-			},
-			esModuleInterop: true,
-			allowJs: true,
-		},
-	});
-
-	project.createDirectory("/src");
-	project.createDirectory("/src/utils");
-	project.createDirectory("/src/components");
-
-	return project;
-};
 
 describe("renameFileSystemEntry Special Cases", () => {
 	it("dryRun: true の場合、ファイルシステム（メモリ上）の変更を行わず、変更予定リストを返す", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldUtilPath = "/src/utils/old-util.ts";
 		const newUtilPath = "/src/utils/new-util.ts";
 		const componentPath = "/src/components/MyComponent.ts";
@@ -55,7 +33,7 @@ describe("renameFileSystemEntry Special Cases", () => {
 	});
 
 	it("どのファイルからも参照されていないファイルをリネームする", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldPath = "/src/utils/unreferenced.ts";
 		const newPath = "/src/utils/renamed-unreferenced.ts";
 		project.createSourceFile(oldPath, "export const lonely = true;");
@@ -75,7 +53,7 @@ describe("renameFileSystemEntry Special Cases", () => {
 	});
 
 	it("デフォルトインポートのパスが正しく更新される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldDefaultPath = "/src/utils/defaultExport.ts";
 		const newDefaultPath = "/src/utils/renamedDefaultExport.ts";
 		const importerPath = "/src/importer.ts";
@@ -106,7 +84,7 @@ describe("renameFileSystemEntry Special Cases", () => {
 	});
 
 	it("デフォルトエクスポートされた変数 (export default variableName) のパスが正しく更新される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldVarDefaultPath = "/src/utils/variableDefaultExport.ts";
 		const newVarDefaultPath = "/src/utils/renamedVariableDefaultExport.ts";
 		const importerPath = "/src/importerVar.ts";
@@ -139,7 +117,7 @@ describe("renameFileSystemEntry Special Cases", () => {
 
 describe("renameFileSystemEntry Extension Preservation", () => {
 	it("import文のパスに .js 拡張子が含まれている場合、リネーム後も維持される", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldJsPath = "/src/utils/legacy-util.js";
 		const newJsPath = "/src/utils/modern-util.js";
 		const importerPath = "/src/components/MyComponent.ts";
@@ -186,7 +164,7 @@ console.log(legacyValue, helperValue);
 
 describe("renameFileSystemEntry with index.ts re-exports", () => {
 	it("index.ts が 'export * from \"./moduleB\"' 形式で moduleB.ts を再エクスポートし、moduleB.ts をリネームした場合", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const utilsDir = "/src/utils";
 		const moduleBOriginalPath = `${utilsDir}/moduleB.ts`;
 		const moduleBRenamedPath = `${utilsDir}/moduleBRenamed.ts`;
@@ -200,7 +178,7 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 		project.createSourceFile(indexTsPath, 'export * from "./moduleB";');
 		project.createSourceFile(
 			componentPath,
-			"import { importantValue } from '@/utils';\\nconsole.log(importantValue);",
+			"import { importantValue } from '@/utils';\nconsole.log(importantValue);",
 		);
 
 		const result = await renameFileSystemEntry({
@@ -235,7 +213,7 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 	});
 
 	it("index.ts が 'export { specificExport } from \"./moduleC\"' 形式で moduleC.ts を再エクスポートし、moduleC.ts をリネームした場合", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const utilsDir = "/src/utils";
 		const moduleCOriginalPath = `${utilsDir}/moduleC.ts`;
 		const moduleCRenamedPath = `${utilsDir}/moduleCRenamed.ts`;
@@ -252,7 +230,7 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 		);
 		project.createSourceFile(
 			componentPath,
-			"import { specificExport } from '@/utils';\\nconsole.log(specificExport);",
+			"import { specificExport } from '@/utils';\nconsole.log(specificExport);",
 		);
 
 		const result = await renameFileSystemEntry({
@@ -291,7 +269,7 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 	});
 
 	it("index.ts が再エクスポートを行い、その utils ディレクトリ全体をリネームした場合", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldUtilsDir = "/src/utils";
 		const newUtilsDir = "/src/newUtils";
 
@@ -306,7 +284,7 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 		project.createSourceFile(indexTsOriginalPath, 'export * from "./moduleD";');
 		project.createSourceFile(
 			componentPath,
-			"import { valueFromD } from '@/utils';\\nconsole.log(valueFromD);",
+			"import { valueFromD } from '@/utils';\nconsole.log(valueFromD);",
 		);
 
 		const result = await renameFileSystemEntry({
@@ -353,7 +331,7 @@ describe("renameFileSystemEntry with index.ts re-exports", () => {
 
 describe("renameFileSystemEntry with type-only namespace import (issue #26)", () => {
 	it("`import type * as X from '@/...'` (type-only namespace import + path-alias) も rename で更新されること", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldTargetPath = "/src/types/request.ts";
 		const newTargetPath = "/src/typings/request.ts";
 		const usagePath = "/src/usage.ts";
@@ -395,7 +373,7 @@ export const b: CreateRequest = { id: "y" };
 	});
 
 	it("`import type * as X from './relative'` (type-only namespace import + 相対パス) が rename で更新されること (回帰防止)", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const oldTargetPath = "/src/types/request.ts";
 		const newTargetPath = "/src/typings/request.ts";
 		const usagePath = "/src/usage.ts";
@@ -432,7 +410,7 @@ export const a: Req.CreateRequest = { id: "x" };
 
 describe("renameFileSystemEntry with index.ts re-exports (actual bug reproduction)", () => {
 	it("index.tsが複数のモジュールを再エクスポートし、そのうちの1つをリネームした際、インポート元のパスがindex.tsを指し続けること", async () => {
-		const project = setupProject();
+		const project = createInMemoryProject();
 		const utilsDir = "/src/utils";
 		const moduleAOriginalPath = `${utilsDir}/moduleA.ts`;
 		const moduleARenamedPath = `${utilsDir}/moduleARenamed.ts`;

--- a/src/ts-morph/rename-file-system/update-module-specifiers.test.ts
+++ b/src/ts-morph/rename-file-system/update-module-specifiers.test.ts
@@ -40,24 +40,26 @@ describe("updateModuleSpecifiers", () => {
 		expect(importDecl.getModuleSpecifierValue()).toBe("./new");
 	});
 
-	it("module specifier がない declaration はスキップする", () => {
+	it("module specifier がない declaration はスキップし、宣言を変更しない", () => {
 		const project = createInMemoryProject();
 		const sf = project.createSourceFile("/src/a.ts", "export {};");
 		const exportDecl = sf.addExportDeclaration({ namedExports: [] });
+		const before = exportDecl.getText();
 
-		expect(() =>
-			updateModuleSpecifiers(
-				[
-					{
-						declaration: exportDecl,
-						resolvedPath: "/src/old.ts",
-						referencingFilePath: "/src/a.ts",
-						originalSpecifierText: "",
-					},
-				],
-				[refOp(sf, "/src/old.ts", "/src/new.ts")],
-			),
-		).not.toThrow();
+		updateModuleSpecifiers(
+			[
+				{
+					declaration: exportDecl,
+					resolvedPath: "/src/old.ts",
+					referencingFilePath: "/src/a.ts",
+					originalSpecifierText: "",
+				},
+			],
+			[refOp(sf, "/src/old.ts", "/src/new.ts")],
+		);
+
+		expect(exportDecl.getModuleSpecifier()).toBeUndefined();
+		expect(exportDecl.getText()).toBe(before);
 	});
 
 	it("resolvedPath にマッチするリネームがない場合はスキップする", () => {
@@ -190,7 +192,8 @@ describe("updateModuleSpecifiers", () => {
 			"export const a = 1;",
 		);
 		const controller = new AbortController();
-		controller.abort();
+		const abortReason = new Error("test-abort");
+		controller.abort(abortReason);
 
 		expect(() =>
 			updateModuleSpecifiers(
@@ -198,6 +201,6 @@ describe("updateModuleSpecifiers", () => {
 				[refOp(target, "/src/old.ts", "/src/new.ts")],
 				controller.signal,
 			),
-		).toThrow();
+		).toThrow(abortReason);
 	});
 });

--- a/src/ts-morph/rename-file-system/update-module-specifiers.test.ts
+++ b/src/ts-morph/rename-file-system/update-module-specifiers.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ImportDeclaration } from "ts-morph";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import type { DeclarationToUpdate, RenameOperation } from "../types";
+import { updateModuleSpecifiers } from "./update-module-specifiers";
+
+vi.mock("../../utils/logger");
+
+const refOp = (
+	sourceFile: RenameOperation["sourceFile"],
+	oldPath: string,
+	newPath: string,
+): RenameOperation => ({ sourceFile, oldPath, newPath });
+
+describe("updateModuleSpecifiers", () => {
+	it("通常の import 文を新しいパスに書き換える", () => {
+		const project = createInMemoryProject();
+		const target = project.createSourceFile(
+			"/src/old.ts",
+			"export const a = 1;",
+		);
+		const importer = project.createSourceFile(
+			"/src/importer.ts",
+			'import { a } from "./old";\nconsole.log(a);',
+		);
+		const importDecl = importer.getImportDeclarations()[0];
+
+		updateModuleSpecifiers(
+			[
+				{
+					declaration: importDecl,
+					resolvedPath: "/src/old.ts",
+					referencingFilePath: "/src/importer.ts",
+					originalSpecifierText: "./old",
+				},
+			],
+			[refOp(target, "/src/old.ts", "/src/new.ts")],
+		);
+
+		expect(importDecl.getModuleSpecifierValue()).toBe("./new");
+	});
+
+	it("module specifier がない declaration はスキップする", () => {
+		const project = createInMemoryProject();
+		const sf = project.createSourceFile("/src/a.ts", "export {};");
+		const exportDecl = sf.addExportDeclaration({ namedExports: [] });
+
+		expect(() =>
+			updateModuleSpecifiers(
+				[
+					{
+						declaration: exportDecl,
+						resolvedPath: "/src/old.ts",
+						referencingFilePath: "/src/a.ts",
+						originalSpecifierText: "",
+					},
+				],
+				[refOp(sf, "/src/old.ts", "/src/new.ts")],
+			),
+		).not.toThrow();
+	});
+
+	it("resolvedPath にマッチするリネームがない場合はスキップする", () => {
+		const project = createInMemoryProject();
+		const target = project.createSourceFile(
+			"/src/other.ts",
+			"export const a = 1;",
+		);
+		const importer = project.createSourceFile(
+			"/src/importer.ts",
+			'import { a } from "./other";\nconsole.log(a);',
+		);
+		const importDecl = importer.getImportDeclarations()[0];
+
+		updateModuleSpecifiers(
+			[
+				{
+					declaration: importDecl,
+					resolvedPath: "/src/unrelated.ts",
+					referencingFilePath: "/src/importer.ts",
+					originalSpecifierText: "./other",
+				},
+			],
+			[refOp(target, "/src/old.ts", "/src/new.ts")],
+		);
+
+		expect(importDecl.getModuleSpecifierValue()).toBe("./other");
+	});
+
+	it(".js 拡張子付き specifier は拡張子を保持する", () => {
+		const project = createInMemoryProject();
+		const target = project.createSourceFile(
+			"/src/old.js",
+			"export const a = 1;",
+		);
+		const importer = project.createSourceFile(
+			"/src/importer.ts",
+			'import { a } from "./old.js";\nconsole.log(a);',
+		);
+		const importDecl = importer.getImportDeclarations()[0];
+
+		updateModuleSpecifiers(
+			[
+				{
+					declaration: importDecl,
+					resolvedPath: "/src/old.js",
+					referencingFilePath: "/src/importer.ts",
+					originalSpecifierText: "./old.js",
+				},
+			],
+			[refOp(target, "/src/old.js", "/src/new.js")],
+		);
+
+		expect(importDecl.getModuleSpecifierValue()).toBe("./new.js");
+	});
+
+	it("path alias 経由のインポートでも相対パスにフォールバックする", () => {
+		const project = createInMemoryProject();
+		const target = project.createSourceFile(
+			"/src/old.ts",
+			"export const a = 1;",
+		);
+		const importer = project.createSourceFile(
+			"/src/feature/importer.ts",
+			'import { a } from "@/old";\nconsole.log(a);',
+		);
+		const importDecl = importer.getImportDeclarations()[0];
+
+		updateModuleSpecifiers(
+			[
+				{
+					declaration: importDecl,
+					resolvedPath: "/src/old.ts",
+					referencingFilePath: "/src/feature/importer.ts",
+					originalSpecifierText: "@/old",
+					wasPathAlias: true,
+				},
+			],
+			[refOp(target, "/src/old.ts", "/src/new.ts")],
+		);
+
+		expect(importDecl.getModuleSpecifierValue()).toBe("../new");
+	});
+
+	it("setModuleSpecifier が throw した場合はスキップして処理を継続する", () => {
+		const project = createInMemoryProject();
+		const target = project.createSourceFile(
+			"/src/old.ts",
+			"export const a = 1;",
+		);
+		const importer = project.createSourceFile(
+			"/src/importer.ts",
+			'import { a } from "./old";\nconsole.log(a);',
+		);
+		const importDecl = importer.getImportDeclarations()[0];
+
+		// 強制的に throw させる
+		const original = importDecl.setModuleSpecifier.bind(importDecl);
+		(
+			importDecl as unknown as { setModuleSpecifier: () => never }
+		).setModuleSpecifier = () => {
+			throw new Error("intentional");
+		};
+
+		try {
+			expect(() =>
+				updateModuleSpecifiers(
+					[
+						{
+							declaration: importDecl,
+							resolvedPath: "/src/old.ts",
+							referencingFilePath: "/src/importer.ts",
+							originalSpecifierText: "./old",
+						},
+					],
+					[refOp(target, "/src/old.ts", "/src/new.ts")],
+				),
+			).not.toThrow();
+		} finally {
+			(
+				importDecl as unknown as { setModuleSpecifier: typeof original }
+			).setModuleSpecifier = original;
+		}
+	});
+
+	it("AbortSignal で中断できる", () => {
+		const project = createInMemoryProject();
+		const target = project.createSourceFile(
+			"/src/old.ts",
+			"export const a = 1;",
+		);
+		const controller = new AbortController();
+		controller.abort();
+
+		expect(() =>
+			updateModuleSpecifiers(
+				[],
+				[refOp(target, "/src/old.ts", "/src/new.ts")],
+				controller.signal,
+			),
+		).toThrow();
+	});
+});

--- a/src/ts-morph/rename-symbol/rename-symbol.test.ts
+++ b/src/ts-morph/rename-symbol/rename-symbol.test.ts
@@ -1,7 +1,11 @@
 import { SyntaxKind, type Identifier } from "ts-morph";
 import { describe, it, expect } from "vitest";
 import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
-import { findIdentifierNode, validateSymbol } from "./rename-symbol";
+import {
+	findAllReferencesAsNodes,
+	findIdentifierNode,
+	validateSymbol,
+} from "./rename-symbol";
 
 const TEST_FILE_PATH = "/test.ts";
 
@@ -92,5 +96,30 @@ describe("validateSymbol", () => {
 		expect(() => validateSymbol(identifier, "wrongName")).toThrowError(
 			new Error("シンボル名が一致しません (期待: wrongName, 実際: myFunc)"),
 		);
+	});
+});
+
+describe("findAllReferencesAsNodes", () => {
+	it("シンボルの定義と参照を全て返す", () => {
+		const project = createInMemoryProject();
+		project.createSourceFile(
+			"/src/lib.ts",
+			"export function target() {}\ntarget();",
+		);
+		project.createSourceFile(
+			"/src/user.ts",
+			'import { target } from "./lib";\ntarget();',
+		);
+
+		const lib = project.getSourceFileOrThrow("/src/lib.ts");
+		const targetIdentifier = lib
+			.getFunctionOrThrow("target")
+			.getNameNodeOrThrow();
+
+		const references = findAllReferencesAsNodes(targetIdentifier);
+
+		const referenceTexts = references.map((node) => node.getText());
+		expect(referenceTexts).toContain("target");
+		expect(references.length).toBeGreaterThanOrEqual(2);
 	});
 });

--- a/src/ts-morph/rename-symbol/rename-symbol.test.ts
+++ b/src/ts-morph/rename-symbol/rename-symbol.test.ts
@@ -1,13 +1,12 @@
-import { Project, SyntaxKind, type Identifier } from "ts-morph";
+import { SyntaxKind, type Identifier } from "ts-morph";
 import { describe, it, expect } from "vitest";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
 import { findIdentifierNode, validateSymbol } from "./rename-symbol";
-
-// --- Test Setup ---
 
 const TEST_FILE_PATH = "/test.ts";
 
 const setupProject = () => {
-	const project = new Project({ useInMemoryFileSystem: true });
+	const project = createInMemoryProject();
 
 	const getIdentifier = (
 		content: string,


### PR DESCRIPTION
## Summary

Cursor + Gemini 時代に書かれたテストコードの保守性を段階的に改善。共通ヘルパー化で重複を削減しつつ、低カバレッジ箇所に集中的にテストを追加した。

- **テスト数**: 203 → **235** (+32)
- **Statements**: 83.19% → **86.5%**
- **Branch**: 78% → **82.76%**
- **Functions**: 93.75% → **96.25%**

## 主な変更

### 共通ヘルパー (`src/ts-morph/_test-utils/`)

- `create-in-memory-project.ts` — in-memory FS + path alias 付き `Project` ファクトリ
- `get-statement.ts` — `findTopLevelDeclarationByName` + 存在チェックを 1 行に
- `get-file-text.ts` — `getSourceFileOrThrow().getFullText()` を 1 行に
- `expect-file-moved.ts` — 旧パス消失 + 新パス存在の対アサーション

### リファクタの効果

| 内容 | 件数 |
|------|------|
| 重複していた `setupProject` / `new Project({...})` を統一 | 17 ファイル |
| `findTopLevelDeclarationByName + as X + toBeDefined()` の三重ボイラープレートを集約 | 3 ファイル |
| `getSourceFile(X)?.getFullText()` の `?` チェイン削減 | 37 箇所 |
| `toBeUndefined / toBeDefined` の対パターンを集約 | 18 箇所 |
| `getIdentifierFromDeclaration` の 14 テストを `it.each` 1 つに | 1 ファイル |
| `special.test.ts` の \\n リテラル混入バグを修正 | 3 箇所 |

### 100% カバレッジ達成ファイル

- `skip-ts-morph-ref-update.ts` (70.2 → 100%)
- `cleanup-empty-old-directories.ts` (66.7 → 100%)
- `update-module-specifiers.ts` (71.9 → 100%)
- `remove-original-symbol.ts` (62.5 → 100%)
- `rename-symbol.ts` Functions (75 → 100%)

### コミット履歴

1. `39b4ae8` refactor(test): in-memory Project の生成を共通ヘルパーに統一
2. `a96ef9a` refactor(test): 内部依存テストの定型 setup を getStatement ヘルパーに集約
3. `02dff80` refactor(test): assertion ヘルパー化とデータドリブン化 (Phase A/B/C)
4. `109ed3d` test: 未カバー分岐に対するテストを追加 (+5 tests)
5. `87aa0e5` test: 低カバレッジ箇所に集中的にテスト追加 (+27 tests)

## Test plan

- [x] \`pnpm test\` … 25 → **29 files** / 203 → **235 passed** / 1 skipped
- [x] \`pnpm check-types\` … クリーン
- [x] \`pnpm lint\` … クリーン
- [x] \`pnpm test:coverage\` … 全体カバレッジ向上を確認

## 残る低カバレッジ (今回スコープ外)

実 IO テスト中心の領域 (\`find-references.test.ts\`, \`mcp/tools/integration.test.ts\`) は将来的に「有名 OSS リポジトリを題材にした E2E テスト」に置換するのが理想 (本 PR ではそのまま残置)。MCP ツール登録の boundary (\`register-*-tool.ts\` 88-92%) も同様。

🤖 Generated with [Claude Code](https://claude.com/claude-code)