### PR TITLE
feat(change-signature): 関数シグネチャ変更を全呼び出し側へ同期する MCP ツール

### DIFF
--- a/src/mcp/tools/integration.test.ts
+++ b/src/mcp/tools/integration.test.ts
@@ -366,6 +366,80 @@ console.log(funcToStay());
 		});
 	});
 
+	describe("change_signature_by_tsmorph", () => {
+		it("先頭に必須パラメータを追加し、呼び出し側を更新する", async () => {
+			const utilsPath = path.join(srcDir, "utils.ts");
+			const consumerPath = path.join(srcDir, "consumer.ts");
+
+			fs.writeFileSync(
+				utilsPath,
+				`export function greet(name: string): string {
+  return "hello " + name;
+}
+`,
+			);
+			fs.writeFileSync(
+				consumerPath,
+				`import { greet } from "./utils";
+
+console.log(greet("world"));
+console.log(greet("there"));
+`,
+			);
+
+			const result = await mockServer.callTool("change_signature_by_tsmorph", {
+				tsconfigPath,
+				targetFilePath: utilsPath,
+				position: { line: 1, column: 17 }, // "greet" の位置
+				functionName: "greet",
+				changes: [
+					{
+						kind: "add",
+						index: 0,
+						name: "lang",
+						typeText: "string",
+						argumentForCallers: '"en"',
+					},
+				],
+				dryRun: false,
+			});
+
+			expect(result).toHaveProperty("isError", false);
+			const updatedUtils = fs.readFileSync(utilsPath, "utf-8");
+			const updatedConsumer = fs.readFileSync(consumerPath, "utf-8");
+
+			expect(updatedUtils).toContain(
+				"function greet(lang: string, name: string)",
+			);
+			expect(updatedConsumer).toContain('greet("en", "world")');
+			expect(updatedConsumer).toContain('greet("en", "there")');
+		});
+
+		it("dryRun ではファイルを変更しない", async () => {
+			const filePath = path.join(srcDir, "fn.ts");
+			fs.writeFileSync(
+				filePath,
+				`export function foo(a: number) { return a; }
+foo(1);
+`,
+			);
+
+			const result = await mockServer.callTool("change_signature_by_tsmorph", {
+				tsconfigPath,
+				targetFilePath: filePath,
+				position: { line: 1, column: 17 },
+				functionName: "foo",
+				changes: [{ kind: "remove", index: 0 }],
+				dryRun: true,
+			});
+
+			expect(result).toHaveProperty("isError", false);
+			const content = fs.readFileSync(filePath, "utf-8");
+			expect(content).toContain("function foo(a: number)");
+			expect(content).toContain("foo(1);");
+		});
+	});
+
 	describe("エラーハンドリング", () => {
 		it("存在しないファイルに対してエラーを返す", async () => {
 			const nonExistentPath = path.join(srcDir, "non-existent.ts");

--- a/src/mcp/tools/register-change-signature-tool.ts
+++ b/src/mcp/tools/register-change-signature-tool.ts
@@ -1,0 +1,206 @@
+import { performance } from "node:perf_hooks";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { changeSignature } from "../../ts-morph/change-signature/change-signature";
+import logger from "../../utils/logger";
+
+const addOpSchema = z.object({
+	kind: z.literal("add"),
+	index: z
+		.number()
+		.int()
+		.nonnegative()
+		.optional()
+		.describe(
+			"0-based insertion index. Omit to append at the end of the parameter list.",
+		),
+	name: z.string().describe("Name of the new parameter."),
+	typeText: z
+		.string()
+		.optional()
+		.describe(
+			'Type annotation text (e.g. "string", "{ id: number }"). Omit for no type annotation.',
+		),
+	optional: z
+		.boolean()
+		.optional()
+		.describe("If true, marks the parameter optional with `?`."),
+	defaultValue: z
+		.string()
+		.optional()
+		.describe(
+			'Default value text (e.g. "0", \'"hello"\'). Sets the parameter initializer.',
+		),
+	argumentForCallers: z
+		.string()
+		.optional()
+		.describe(
+			"Argument expression text to insert into every existing call site. REQUIRED when inserting a parameter in the middle, OR when the new parameter is required (no defaultValue/optional) AND existing callers must be updated. Omit ONLY when the new parameter is trailing optional/defaulted and you want callers to remain unchanged.",
+		),
+});
+
+const removeOpSchema = z.object({
+	kind: z.literal("remove"),
+	index: z
+		.number()
+		.int()
+		.nonnegative()
+		.describe("0-based index of the parameter to remove."),
+});
+
+const reorderOpSchema = z.object({
+	kind: z.literal("reorder"),
+	newOrder: z
+		.array(z.number().int().nonnegative())
+		.describe(
+			"Array describing the new order. Length must equal the current parameter count, each old index appears exactly once. Example: [2, 0, 1] means new[0]=old[2], new[1]=old[0], new[2]=old[1].",
+		),
+});
+
+const operationSchema = z.discriminatedUnion("kind", [
+	addOpSchema,
+	removeOpSchema,
+	reorderOpSchema,
+]);
+
+export function registerChangeSignatureTool(server: McpServer): void {
+	server.tool(
+		"change_signature_by_tsmorph",
+		`[ts-morph] Add, remove, or reorder parameters of a function/method/arrow-function and propagate the matching argument changes to every call site in the project.
+
+## When to use
+- Adding a required parameter to a function with many callers (LLM single-edit reliably misses some — this tool guarantees every call site is updated via the type checker).
+- Removing or reordering parameters of a function that is imported, re-exported, or accessed through a method chain.
+- Inserting a context-like first parameter (\`ctx\`, \`logger\`, etc.) into existing helpers.
+
+## When NOT to use
+- Renaming a parameter — use \`rename_symbol_by_tsmorph\` on the parameter identifier instead.
+- Changing only the parameter's type annotation without changing arity — edit the source file directly.
+- Moving the function to another file — use \`move_symbol_to_file_by_tsmorph\`.
+
+## Critical constraints
+- \`position\` must point at the function's name identifier (1-based line/column). For \`const foo = () => {}\`, point at \`foo\`; for \`class C { foo() {} }\`, point at \`foo\`.
+- \`functionName\` must match the identifier text at that position (sanity check).
+- All paths (\`tsconfigPath\`, \`targetFilePath\`) MUST be absolute.
+- **Spread arguments** (\`fn(...args)\`) at call sites cause the operation to fail when a change would modify arguments. Refactor those callers manually first, or limit changes to trailing optional/defaulted parameters with no \`argumentForCallers\`.
+- Operations apply sequentially; later operations see the parameter list produced by earlier ones.
+
+## Operation semantics
+- **add**: Inserts a parameter at \`index\` (default: end). If \`argumentForCallers\` is provided, that exact text is inserted at the same index in every call site. If omitted, callers are left untouched (use only for trailing optional / defaulted parameters).
+- **remove**: Removes the parameter at \`index\`. Each call site with at least that many arguments drops the corresponding one. Calls passing fewer arguments are left untouched.
+- **reorder**: Rebuilds the parameter list and every call site according to \`newOrder\`. Fails if any call site does not pass exactly that many arguments (no way to safely reorder omitted optionals).
+
+## Tips
+- Run with \`dryRun: true\` first when the function has many callers to preview the impacted files.
+- For adding multiple parameters at once, list multiple \`add\` operations; their \`index\` values refer to the parameter list *after* prior operations in the same call have been applied.
+
+## Result
+Returns the list of modified (or to-be-modified, in dryRun) file paths, plus status and processing time.`,
+		{
+			tsconfigPath: z
+				.string()
+				.describe("Path to the project's tsconfig.json file."),
+			targetFilePath: z
+				.string()
+				.describe("Path to the file containing the function declaration."),
+			position: z
+				.object({
+					line: z.number().int().positive().describe("1-based line number."),
+					column: z
+						.number()
+						.int()
+						.positive()
+						.describe("1-based column number."),
+				})
+				.describe("Exact position of the function name identifier."),
+			functionName: z
+				.string()
+				.describe("Name of the function/method at that position."),
+			changes: z
+				.array(operationSchema)
+				.min(1)
+				.describe(
+					"Ordered list of signature operations to apply. See the tool description for semantics.",
+				),
+			dryRun: z
+				.boolean()
+				.optional()
+				.default(false)
+				.describe(
+					"If true, only show intended changes without modifying files.",
+				),
+		},
+		async (args) => {
+			const startTime = performance.now();
+			let message = "";
+			let isError = false;
+			let duration = "0.00";
+			let changedFilesCount = 0;
+
+			const logArgs = {
+				targetFilePath: args.targetFilePath,
+				functionName: args.functionName,
+				operationKinds: args.changes.map((c) => c.kind),
+				dryRun: args.dryRun,
+			};
+
+			try {
+				const result = await changeSignature({
+					tsconfigPath: args.tsconfigPath,
+					targetFilePath: args.targetFilePath,
+					position: args.position,
+					functionName: args.functionName,
+					changes: args.changes,
+					dryRun: args.dryRun,
+				});
+
+				changedFilesCount = result.changedFiles.length;
+				const changedFilesList =
+					result.changedFiles.length > 0
+						? result.changedFiles.join("\n - ")
+						: "(No changes)";
+
+				if (args.dryRun) {
+					message = `Dry run complete: Changing signature of '${args.functionName}' would modify the following files:\n - ${changedFilesList}`;
+				} else {
+					message = `Signature change successful for '${args.functionName}'. The following files were modified:\n - ${changedFilesList}`;
+				}
+			} catch (error) {
+				logger.error(
+					{ err: error, toolArgs: logArgs },
+					"Error executing change_signature_by_tsmorph",
+				);
+				const errorMessage =
+					error instanceof Error ? error.message : String(error);
+				message = `Error during change_signature: ${errorMessage}`;
+				isError = true;
+			} finally {
+				const endTime = performance.now();
+				duration = ((endTime - startTime) / 1000).toFixed(2);
+				logger.info(
+					{
+						status: isError ? "Failure" : "Success",
+						durationMs: Number.parseFloat((endTime - startTime).toFixed(2)),
+						changedFilesCount,
+						...logArgs,
+					},
+					"change_signature_by_tsmorph tool finished",
+				);
+				try {
+					logger.flush();
+				} catch (flushErr) {
+					console.error("Failed to flush logs:", flushErr);
+				}
+			}
+
+			const finalMessage = `${message}\nStatus: ${
+				isError ? "Failure" : "Success"
+			}\nProcessing time: ${duration} seconds`;
+
+			return {
+				content: [{ type: "text", text: finalMessage }],
+				isError,
+			};
+		},
+	);
+}

--- a/src/mcp/tools/ts-morph-tools.ts
+++ b/src/mcp/tools/ts-morph-tools.ts
@@ -1,10 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-import { registerRenameSymbolTool } from "./register-rename-symbol-tool";
-import { registerRenameFileSystemEntryTool } from "./register-rename-file-system-entry-tool";
+import { registerChangeSignatureTool } from "./register-change-signature-tool";
 import { registerFindReferencesTool } from "./register-find-references-tool";
-import { registerRemovePathAliasTool } from "./register-remove-path-alias-tool";
 import { registerMoveSymbolToFileTool } from "./register-move-symbol-to-file-tool";
+import { registerRemovePathAliasTool } from "./register-remove-path-alias-tool";
+import { registerRenameFileSystemEntryTool } from "./register-rename-file-system-entry-tool";
+import { registerRenameSymbolTool } from "./register-rename-symbol-tool";
 
 /**
  * ts-morph を利用したリファクタリングツール群を MCP サーバーに登録する
@@ -15,4 +16,5 @@ export function registerTsMorphTools(server: McpServer): void {
 	registerFindReferencesTool(server);
 	registerRemovePathAliasTool(server);
 	registerMoveSymbolToFileTool(server);
+	registerChangeSignatureTool(server);
 }

--- a/src/ts-morph/change-signature/apply-changes.ts
+++ b/src/ts-morph/change-signature/apply-changes.ts
@@ -1,0 +1,184 @@
+import {
+	type CallExpression,
+	Node,
+	type OptionalKind,
+	type ParameterDeclarationStructure,
+} from "ts-morph";
+import type { FunctionLikeWithParameters } from "./find-function-declaration";
+import type { ChangeSignatureOperation } from "./types";
+
+/**
+ * 既存呼び出しの引数テキスト配列に対して、操作列を適用して新しい引数配列を計算する。
+ *
+ * - add: argumentForCallers が指定されていれば、index 位置に挿入する。
+ *   index が現在の引数数を超えていれば呼び出しに必要な引数が欠けているのでエラー。
+ *   argumentForCallers 未指定の場合は呼び出し側に変更を入れない (末尾追加で
+ *   optional/defaulted パラメータを想定したケース)。
+ * - remove: index が範囲内ならその位置を削除。範囲外なら無変更 (省略された optional 引数のため)。
+ * - reorder: 呼び出しの引数数が newOrder の長さと一致しない場合はエラー。
+ */
+export function computeNewArgumentTexts(
+	currentArgTexts: readonly string[],
+	operations: readonly ChangeSignatureOperation[],
+): string[] {
+	let args = [...currentArgTexts];
+	for (const op of operations) {
+		if (op.kind === "add") {
+			if (op.argumentForCallers === undefined) continue;
+			const insertAt = op.index ?? args.length;
+			if (insertAt > args.length) {
+				throw new Error(
+					`add 操作: index=${insertAt} に挿入しようとしましたが、呼び出しは ${args.length} 個の引数しか渡していません。末尾 optional を省略している呼び出しがあるため、追加位置を末尾以外にする場合は、先に対象呼び出しに引数を補完してから再実行してください。`,
+				);
+			}
+			args.splice(insertAt, 0, op.argumentForCallers);
+			continue;
+		}
+		if (op.kind === "remove") {
+			if (op.index >= 0 && op.index < args.length) {
+				args.splice(op.index, 1);
+			}
+			continue;
+		}
+		if (op.kind === "reorder") {
+			if (args.length !== op.newOrder.length) {
+				throw new Error(
+					`Reorder requires call sites to pass all ${op.newOrder.length} arguments, but a call passes ${args.length}.`,
+				);
+			}
+			args = op.newOrder.map((index) => args[index]);
+		}
+	}
+	return args;
+}
+
+/**
+ * 関数の Parameter 構造体配列に対して操作列を適用して、新しい構造体配列を計算する。
+ *
+ * - add の中間挿入で argumentForCallers が無いケースは、呼び出し側が壊れるためここで弾く。
+ * - rest パラメータが末尾以外に配置される配列は TypeScript 上不正なので拒否する。
+ */
+export function computeNewParameterStructures(
+	current: ReadonlyArray<OptionalKind<ParameterDeclarationStructure>>,
+	operations: readonly ChangeSignatureOperation[],
+): OptionalKind<ParameterDeclarationStructure>[] {
+	let params: OptionalKind<ParameterDeclarationStructure>[] = current.map(
+		(p) => ({ ...p }),
+	);
+	for (const op of operations) {
+		if (op.kind === "add") {
+			const insertAt = op.index ?? params.length;
+			if (insertAt < 0 || insertAt > params.length) {
+				throw new Error(
+					`add 操作の index=${insertAt} がパラメータ範囲 [0, ${params.length}] を超えています`,
+				);
+			}
+			const isTrailing = insertAt === params.length;
+			const isSafelyOmittable =
+				op.optional === true || op.defaultValue !== undefined;
+			if (op.argumentForCallers === undefined) {
+				if (!isTrailing) {
+					throw new Error(
+						`add 操作: 中間 index=${insertAt} に挿入する場合は argumentForCallers が必須です (呼び出し側の既存引数と新パラメータの対応が崩れるため)。`,
+					);
+				}
+				if (!isSafelyOmittable) {
+					throw new Error(
+						"add 操作: 末尾追加でも argumentForCallers を省略する場合は、新パラメータが " +
+							"optional または defaultValue を持つ必要があります (既存呼び出しが引数不足になるため)。",
+					);
+				}
+			}
+			params.splice(insertAt, 0, {
+				name: op.name,
+				type: op.typeText,
+				hasQuestionToken: op.optional,
+				initializer: op.defaultValue,
+			});
+			continue;
+		}
+		if (op.kind === "remove") {
+			if (op.index < 0 || op.index >= params.length) {
+				throw new Error(
+					`remove 操作の index=${op.index} がパラメータ範囲 [0, ${params.length - 1}] を超えています`,
+				);
+			}
+			params.splice(op.index, 1);
+			continue;
+		}
+		if (op.kind === "reorder") {
+			if (op.newOrder.length !== params.length) {
+				throw new Error(
+					`reorder の newOrder 長 (${op.newOrder.length}) が現在のパラメータ数 (${params.length}) と一致しません`,
+				);
+			}
+			const seen = new Set<number>();
+			for (const i of op.newOrder) {
+				if (i < 0 || i >= params.length || seen.has(i)) {
+					throw new Error(
+						`reorder の newOrder=[${op.newOrder.join(",")}] が不正です (重複/範囲外)`,
+					);
+				}
+				seen.add(i);
+			}
+			params = op.newOrder.map((i) => params[i]);
+		}
+	}
+	validateRestParameterIsLast(params);
+	return params;
+}
+
+/**
+ * rest パラメータ (`...rest`) は末尾でなければならない (TS2369)。
+ */
+export function validateRestParameterIsLast(
+	params: ReadonlyArray<OptionalKind<ParameterDeclarationStructure>>,
+): void {
+	const restIndex = params.findIndex((p) => p.isRestParameter === true);
+	if (restIndex !== -1 && restIndex !== params.length - 1) {
+		throw new Error(
+			`rest パラメータ (index=${restIndex}, name='${params[restIndex].name}') は最後の位置にある必要があります ` +
+				`(現在のパラメータ数: ${params.length})。`,
+		);
+	}
+}
+
+/**
+ * 呼び出し式の引数を一括で newArgTexts に置換する。
+ */
+export function rewriteCallArguments(
+	call: CallExpression,
+	newArgTexts: readonly string[],
+): void {
+	const existingCount = call.getArguments().length;
+	for (let i = existingCount - 1; i >= 0; i--) {
+		call.removeArgument(i);
+	}
+	if (newArgTexts.length > 0) {
+		call.addArguments([...newArgTexts]);
+	}
+}
+
+/**
+ * 関数のパラメータを一括で newParams に置換する。
+ */
+export function rewriteParameters(
+	fn: FunctionLikeWithParameters,
+	newParams: ReadonlyArray<OptionalKind<ParameterDeclarationStructure>>,
+): void {
+	const existing = fn.getParameters();
+	for (const p of [...existing].reverse()) {
+		p.remove();
+	}
+	if (newParams.length > 0) {
+		fn.addParameters([...newParams]);
+	}
+}
+
+/**
+ * 呼び出し式の引数に SpreadElement が含まれているか判定する。
+ * (`fn(...args)` のような呼び出しは静的に位置を変更できない)
+ */
+export function callHasSpreadArgument(call: CallExpression): boolean {
+	return call.getArguments().some((a) => Node.isSpreadElement(a));
+}

--- a/src/ts-morph/change-signature/change-signature.test.ts
+++ b/src/ts-morph/change-signature/change-signature.test.ts
@@ -1,0 +1,590 @@
+import type { Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import { findIdentifierNode } from "../rename-symbol/rename-symbol";
+import {
+	computeNewArgumentTexts,
+	computeNewParameterStructures,
+	validateRestParameterIsLast,
+} from "./apply-changes";
+import { changeSignatureOnProject } from "./change-signature";
+import { filterCallSites } from "./find-call-sites";
+import {
+	findFunctionLikeDeclaration,
+	getAllRelatedFunctionDeclarations,
+} from "./find-function-declaration";
+import type { ChangeSignatureOperation } from "./types";
+
+function setup(files: Record<string, string>): Project {
+	const project = createInMemoryProject();
+	for (const [path, content] of Object.entries(files)) {
+		project.createSourceFile(path, content, { overwrite: true });
+	}
+	return project;
+}
+
+describe("computeNewArgumentTexts", () => {
+	it("add: argumentForCallers が指定されていれば指定 index に挿入", () => {
+		const result = computeNewArgumentTexts(
+			["a", "b"],
+			[{ kind: "add", index: 1, name: "x", argumentForCallers: "ctx" }],
+		);
+		expect(result).toEqual(["a", "ctx", "b"]);
+	});
+
+	it("add: argumentForCallers が無ければ呼び出し引数は変えない", () => {
+		const result = computeNewArgumentTexts(
+			["a"],
+			[{ kind: "add", name: "x", defaultValue: "0" }],
+		);
+		expect(result).toEqual(["a"]);
+	});
+
+	it("add: index が呼び出しの引数数を超える場合はエラー", () => {
+		expect(() =>
+			computeNewArgumentTexts(
+				[],
+				[
+					{
+						kind: "add",
+						index: 2,
+						name: "c",
+						argumentForCallers: "9",
+					},
+				],
+			),
+		).toThrow(/index=2 に挿入/);
+	});
+
+	it("remove: 指定 index の引数を削除", () => {
+		const result = computeNewArgumentTexts(
+			["a", "b", "c"],
+			[{ kind: "remove", index: 1 }],
+		);
+		expect(result).toEqual(["a", "c"]);
+	});
+
+	it("remove: 引数数が足りない (省略 optional) 場合は無変更", () => {
+		const result = computeNewArgumentTexts(
+			["a"],
+			[{ kind: "remove", index: 2 }],
+		);
+		expect(result).toEqual(["a"]);
+	});
+
+	it("reorder: newOrder に従い並び替える", () => {
+		const result = computeNewArgumentTexts(
+			["a", "b", "c"],
+			[{ kind: "reorder", newOrder: [2, 0, 1] }],
+		);
+		expect(result).toEqual(["c", "a", "b"]);
+	});
+
+	it("reorder: 引数数が不一致ならエラー", () => {
+		expect(() =>
+			computeNewArgumentTexts(
+				["a", "b"],
+				[{ kind: "reorder", newOrder: [2, 0, 1] }],
+			),
+		).toThrow(/Reorder requires call sites/);
+	});
+
+	it("複数操作を順次適用", () => {
+		const result = computeNewArgumentTexts(
+			["a", "b"],
+			[
+				{ kind: "add", index: 0, name: "x", argumentForCallers: "ctx" },
+				{ kind: "remove", index: 2 },
+			],
+		);
+		// after add: [ctx, a, b], after remove index 2: [ctx, a]
+		expect(result).toEqual(["ctx", "a"]);
+	});
+});
+
+describe("computeNewParameterStructures", () => {
+	it("add: 末尾に追加 (index 省略)", () => {
+		const result = computeNewParameterStructures(
+			[{ name: "a", type: "string" }],
+			[{ kind: "add", name: "b", typeText: "number", defaultValue: "0" }],
+		);
+		expect(result).toEqual([
+			{ name: "a", type: "string" },
+			{
+				name: "b",
+				type: "number",
+				hasQuestionToken: undefined,
+				initializer: "0",
+			},
+		]);
+	});
+
+	it("add: 中間挿入で argumentForCallers 未指定はエラー", () => {
+		expect(() =>
+			computeNewParameterStructures(
+				[{ name: "a" }, { name: "b" }],
+				[{ kind: "add", index: 1, name: "x", typeText: "string" }],
+			),
+		).toThrow(/argumentForCallers が必須/);
+	});
+
+	it("add: 末尾追加でも optional/default が無く argumentForCallers も無いとエラー", () => {
+		expect(() =>
+			computeNewParameterStructures(
+				[{ name: "a" }],
+				[{ kind: "add", name: "b", typeText: "string" }],
+			),
+		).toThrow(/optional または defaultValue/);
+	});
+
+	it("remove: index が範囲外ならエラー", () => {
+		expect(() =>
+			computeNewParameterStructures(
+				[{ name: "a" }],
+				[{ kind: "remove", index: 1 }],
+			),
+		).toThrow(/範囲/);
+	});
+
+	it("reorder: 長さ不一致はエラー", () => {
+		expect(() =>
+			computeNewParameterStructures(
+				[{ name: "a" }, { name: "b" }],
+				[{ kind: "reorder", newOrder: [0] }],
+			),
+		).toThrow(/newOrder/);
+	});
+
+	it("reorder: 重複した index はエラー", () => {
+		expect(() =>
+			computeNewParameterStructures(
+				[{ name: "a" }, { name: "b" }],
+				[{ kind: "reorder", newOrder: [0, 0] }],
+			),
+		).toThrow(/重複|range/i);
+	});
+
+	it("rest パラメータを reorder で末尾以外に動かすとエラー", () => {
+		expect(() =>
+			computeNewParameterStructures(
+				[{ name: "a" }, { name: "rest", isRestParameter: true }],
+				[{ kind: "reorder", newOrder: [1, 0] }],
+			),
+		).toThrow(/rest パラメータ/);
+	});
+
+	it("rest パラメータの後ろに add するとエラー", () => {
+		expect(() =>
+			computeNewParameterStructures(
+				[{ name: "rest", isRestParameter: true }],
+				[
+					{
+						kind: "add",
+						name: "b",
+						typeText: "string",
+						argumentForCallers: '"x"',
+					},
+				],
+			),
+		).toThrow(/rest パラメータ/);
+	});
+});
+
+describe("validateRestParameterIsLast", () => {
+	it("rest が末尾なら OK", () => {
+		expect(() =>
+			validateRestParameterIsLast([
+				{ name: "a" },
+				{ name: "rest", isRestParameter: true },
+			]),
+		).not.toThrow();
+	});
+
+	it("rest が中間にあるとエラー", () => {
+		expect(() =>
+			validateRestParameterIsLast([
+				{ name: "rest", isRestParameter: true },
+				{ name: "b" },
+			]),
+		).toThrow(/rest パラメータ/);
+	});
+});
+
+describe("findFunctionLikeDeclaration", () => {
+	it("関数宣言を取得できる", () => {
+		const project = setup({
+			"/a.ts": "export function foo(a: number) { return a; }",
+		});
+		const id = findIdentifierNode(project, "/a.ts", { line: 1, column: 17 });
+		const fn = findFunctionLikeDeclaration(id);
+		expect(fn.getParameters()).toHaveLength(1);
+	});
+
+	it("アロー関数代入を取得できる", () => {
+		const project = setup({
+			"/a.ts": "export const foo = (a: number) => a;",
+		});
+		const id = findIdentifierNode(project, "/a.ts", { line: 1, column: 14 });
+		const fn = findFunctionLikeDeclaration(id);
+		expect(fn.getParameters()).toHaveLength(1);
+	});
+
+	it("メソッド宣言を取得できる", () => {
+		const project = setup({
+			"/a.ts": "export class C { foo(a: number) { return a; } }",
+		});
+		const id = findIdentifierNode(project, "/a.ts", { line: 1, column: 18 });
+		const fn = findFunctionLikeDeclaration(id);
+		expect(fn.getParameters()).toHaveLength(1);
+	});
+
+	it("GetAccessor / SetAccessor を取得できる", () => {
+		const project = setup({
+			"/a.ts": [
+				"export class C {",
+				"  get foo() { return 1; }",
+				"  set foo(v: number) { /* */ }",
+				"}",
+			].join("\n"),
+		});
+		const getterId = findIdentifierNode(project, "/a.ts", {
+			line: 2,
+			column: 7,
+		});
+		const setterId = findIdentifierNode(project, "/a.ts", {
+			line: 3,
+			column: 7,
+		});
+		expect(findFunctionLikeDeclaration(getterId).getKindName()).toBe(
+			"GetAccessor",
+		);
+		expect(findFunctionLikeDeclaration(setterId).getKindName()).toBe(
+			"SetAccessor",
+		);
+	});
+
+	it("関数でない位置 (パラメータ) を指すと種別を含むエラー", () => {
+		const project = setup({
+			"/a.ts": "export function bar(foo: string) { return foo; }",
+		});
+		const id = findIdentifierNode(project, "/a.ts", { line: 1, column: 21 });
+		expect(() => findFunctionLikeDeclaration(id)).toThrow(
+			/関数宣言\/メソッド\/関数式ではありません.*Parameter/,
+		);
+	});
+});
+
+describe("getAllRelatedFunctionDeclarations", () => {
+	it("オーバーロード無しなら単独", () => {
+		const project = setup({
+			"/a.ts": "export function foo(a: number) { return a; }",
+		});
+		const id = findIdentifierNode(project, "/a.ts", { line: 1, column: 17 });
+		const fn = findFunctionLikeDeclaration(id);
+		expect(getAllRelatedFunctionDeclarations(fn)).toHaveLength(1);
+	});
+
+	it("オーバーロード implementation を指せば全 signature を返す", () => {
+		const project = setup({
+			"/a.ts": [
+				"export function foo(a: string): string;",
+				"export function foo(a: number): number;",
+				"export function foo(a: string | number) { return a; }",
+			].join("\n"),
+		});
+		const id = findIdentifierNode(project, "/a.ts", { line: 3, column: 17 });
+		const fn = findFunctionLikeDeclaration(id);
+		const all = getAllRelatedFunctionDeclarations(fn);
+		expect(all).toHaveLength(3);
+	});
+
+	it("オーバーロード signature 側を指しても全 signature を返す", () => {
+		const project = setup({
+			"/a.ts": [
+				"export function foo(a: string): string;",
+				"export function foo(a: number): number;",
+				"export function foo(a: string | number) { return a; }",
+			].join("\n"),
+		});
+		const id = findIdentifierNode(project, "/a.ts", { line: 1, column: 17 });
+		const fn = findFunctionLikeDeclaration(id);
+		const all = getAllRelatedFunctionDeclarations(fn);
+		expect(all).toHaveLength(3);
+	});
+});
+
+describe("filterCallSites", () => {
+	it("呼び出し位置のみを抽出する (代入や型注釈は含めない)", () => {
+		const project = setup({
+			"/a.ts": [
+				"export function foo(a: number) { return a; }",
+				"foo(1);",
+				"const ref = foo;",
+				"foo(2);",
+			].join("\n"),
+		});
+		const id = findIdentifierNode(project, "/a.ts", { line: 1, column: 17 });
+		const refs = id.findReferencesAsNodes();
+		const calls = filterCallSites(refs);
+		expect(calls).toHaveLength(2);
+		expect(calls[0].getText()).toBe("foo(1)");
+		expect(calls[1].getText()).toBe("foo(2)");
+	});
+});
+
+// ---- 統合テスト (実 changeSignatureOnProject を通す) ----
+
+async function run(
+	project: Project,
+	args: {
+		targetFilePath: string;
+		position: { line: number; column: number };
+		functionName: string;
+		changes: ChangeSignatureOperation[];
+	},
+) {
+	return changeSignatureOnProject(project, {
+		...args,
+		dryRun: true, // テストでは保存しない
+	});
+}
+
+describe("changeSignatureOnProject", () => {
+	it("add: 末尾にデフォルト値付きパラメータを追加し、呼び出し側は変えない", async () => {
+		const project = setup({
+			"/a.ts": ["export function foo(a: number) { return a; }", "foo(1);"].join(
+				"\n",
+			),
+			"/b.ts": ['import { foo } from "./a";', "foo(2);"].join("\n"),
+		});
+		await run(project, {
+			targetFilePath: "/a.ts",
+			position: { line: 1, column: 17 },
+			functionName: "foo",
+			changes: [
+				{ kind: "add", name: "b", typeText: "number", defaultValue: "0" },
+			],
+		});
+		const a = project.getSourceFileOrThrow("/a.ts").getFullText();
+		const b = project.getSourceFileOrThrow("/b.ts").getFullText();
+		expect(a).toContain("function foo(a: number, b: number = 0)");
+		expect(a).toContain("foo(1);");
+		expect(b).toContain("foo(2);");
+	});
+
+	it("add: 先頭に必須パラメータを追加し、全呼び出しに引数を挿入", async () => {
+		const project = setup({
+			"/a.ts": ["export function foo(a: number) {}", "foo(1);"].join("\n"),
+			"/b.ts": ['import { foo } from "./a";', "foo(2);", "foo(3);"].join("\n"),
+		});
+		await run(project, {
+			targetFilePath: "/a.ts",
+			position: { line: 1, column: 17 },
+			functionName: "foo",
+			changes: [
+				{
+					kind: "add",
+					index: 0,
+					name: "ctx",
+					typeText: "string",
+					argumentForCallers: '"ctx"',
+				},
+			],
+		});
+		const a = project.getSourceFileOrThrow("/a.ts").getFullText();
+		const b = project.getSourceFileOrThrow("/b.ts").getFullText();
+		expect(a).toContain("function foo(ctx: string, a: number)");
+		expect(a).toContain('foo("ctx", 1);');
+		expect(b).toContain('foo("ctx", 2);');
+		expect(b).toContain('foo("ctx", 3);');
+	});
+
+	it("remove: パラメータと対応する引数を削除", async () => {
+		const project = setup({
+			"/a.ts": [
+				"export function foo(a: number, b: string, c: boolean) {}",
+				'foo(1, "x", true);',
+			].join("\n"),
+		});
+		await run(project, {
+			targetFilePath: "/a.ts",
+			position: { line: 1, column: 17 },
+			functionName: "foo",
+			changes: [{ kind: "remove", index: 1 }],
+		});
+		const a = project.getSourceFileOrThrow("/a.ts").getFullText();
+		expect(a).toContain("function foo(a: number, c: boolean)");
+		expect(a).toContain("foo(1, true);");
+	});
+
+	it("reorder: パラメータと引数を並び替え", async () => {
+		const project = setup({
+			"/a.ts": [
+				"export function foo(a: number, b: string, c: boolean) {}",
+				'foo(1, "x", true);',
+			].join("\n"),
+		});
+		await run(project, {
+			targetFilePath: "/a.ts",
+			position: { line: 1, column: 17 },
+			functionName: "foo",
+			changes: [{ kind: "reorder", newOrder: [2, 0, 1] }],
+		});
+		const a = project.getSourceFileOrThrow("/a.ts").getFullText();
+		expect(a).toContain("function foo(c: boolean, a: number, b: string)");
+		expect(a).toContain('foo(true, 1, "x");');
+	});
+
+	it("メソッド呼び出しも更新する", async () => {
+		const project = setup({
+			"/a.ts": [
+				"export class C {",
+				"  foo(a: number) { return a; }",
+				"}",
+				"const c = new C();",
+				"c.foo(1);",
+			].join("\n"),
+		});
+		await run(project, {
+			targetFilePath: "/a.ts",
+			position: { line: 2, column: 3 },
+			functionName: "foo",
+			changes: [
+				{
+					kind: "add",
+					index: 0,
+					name: "ctx",
+					typeText: "string",
+					argumentForCallers: '"x"',
+				},
+			],
+		});
+		const text = project.getSourceFileOrThrow("/a.ts").getFullText();
+		expect(text).toContain("foo(ctx: string, a: number)");
+		expect(text).toContain('c.foo("x", 1);');
+	});
+
+	it("オーバーロード関数: 全 signature と implementation を同時に更新", async () => {
+		const project = setup({
+			"/a.ts": [
+				"export function foo(a: string): string;",
+				"export function foo(a: number): number;",
+				"export function foo(a: string | number) { return a; }",
+				'foo("hi");',
+				"foo(1);",
+			].join("\n"),
+		});
+		await run(project, {
+			targetFilePath: "/a.ts",
+			position: { line: 3, column: 17 }, // implementation
+			functionName: "foo",
+			changes: [
+				{
+					kind: "add",
+					index: 0,
+					name: "ctx",
+					typeText: "string",
+					argumentForCallers: '"c"',
+				},
+			],
+		});
+		const a = project.getSourceFileOrThrow("/a.ts").getFullText();
+		expect(a).toContain("function foo(ctx: string, a: string): string");
+		expect(a).toContain("function foo(ctx: string, a: number): number");
+		expect(a).toContain("function foo(ctx: string, a: string | number)");
+		expect(a).toContain('foo("c", "hi");');
+		expect(a).toContain('foo("c", 1);');
+	});
+
+	it("スプレッド呼び出しがあり引数を変更する場合はエラー (部分適用しない)", async () => {
+		const original = [
+			"export function foo(a: number, b: number) {}",
+			"const args: [number, number] = [1, 2];",
+			"foo(...args);",
+			"foo(3, 4);",
+		].join("\n");
+		const project = setup({ "/a.ts": original });
+
+		await expect(
+			run(project, {
+				targetFilePath: "/a.ts",
+				position: { line: 1, column: 17 },
+				functionName: "foo",
+				changes: [{ kind: "remove", index: 0 }],
+			}),
+		).rejects.toThrow(/スプレッド引数/);
+
+		// 部分適用されていないこと (foo(3, 4) が元のまま)
+		expect(project.getSourceFileOrThrow("/a.ts").getFullText()).toContain(
+			"foo(3, 4);",
+		);
+	});
+
+	it("plan フェーズで検証エラー: 呼び出しの引数数不足が混在 → 部分適用しない", async () => {
+		const project = setup({
+			"/a.ts": [
+				"export function foo(a: number, b: number) { return a + b; }",
+				"foo(1, 2);",
+				"foo(3, 4);",
+			].join("\n"),
+			// 引数数が足りない呼び出しを別ファイルに置く
+			"/b.ts": [
+				'import { foo } from "./a";',
+				"// @ts-expect-error 引数不足を意図的に",
+				"foo(99);",
+			].join("\n"),
+		});
+
+		await expect(
+			run(project, {
+				targetFilePath: "/a.ts",
+				position: { line: 1, column: 17 },
+				functionName: "foo",
+				changes: [{ kind: "reorder", newOrder: [1, 0] }],
+			}),
+		).rejects.toThrow(/Reorder requires/);
+
+		// 部分適用されていないこと (a.ts の呼び出しは元のまま)
+		const a = project.getSourceFileOrThrow("/a.ts").getFullText();
+		expect(a).toContain("foo(1, 2);");
+		expect(a).toContain("foo(3, 4);");
+	});
+
+	it("add 中間挿入で argumentForCallers が無いとエラー", async () => {
+		const project = setup({
+			"/a.ts": [
+				"export function foo(a: string, b: string) {}",
+				'foo("x","y");',
+			].join("\n"),
+		});
+		await expect(
+			run(project, {
+				targetFilePath: "/a.ts",
+				position: { line: 1, column: 17 },
+				functionName: "foo",
+				changes: [{ kind: "add", index: 1, name: "ctx", typeText: "string" }],
+			}),
+		).rejects.toThrow(/argumentForCallers が必須/);
+	});
+
+	it("rest パラメータの後ろに add するとエラー", async () => {
+		const project = setup({
+			"/a.ts": "export function foo(...rest: number[]) {}\nfoo(1, 2);",
+		});
+		await expect(
+			run(project, {
+				targetFilePath: "/a.ts",
+				position: { line: 1, column: 17 },
+				functionName: "foo",
+				changes: [
+					{
+						kind: "add",
+						name: "b",
+						typeText: "string",
+						optional: true,
+					},
+				],
+			}),
+		).rejects.toThrow(/rest パラメータ/);
+	});
+});

--- a/src/ts-morph/change-signature/change-signature.ts
+++ b/src/ts-morph/change-signature/change-signature.ts
@@ -1,0 +1,205 @@
+import type {
+	CallExpression,
+	OptionalKind,
+	ParameterDeclarationStructure,
+	Project,
+} from "ts-morph";
+import logger from "../../utils/logger";
+import {
+	getChangedFiles,
+	initializeProject,
+	saveProjectChanges,
+} from "../_utils/ts-morph-project";
+import {
+	findIdentifierNode,
+	validateSymbol,
+} from "../rename-symbol/rename-symbol";
+import {
+	callHasSpreadArgument,
+	computeNewArgumentTexts,
+	computeNewParameterStructures,
+	rewriteCallArguments,
+	rewriteParameters,
+} from "./apply-changes";
+import { filterCallSites } from "./find-call-sites";
+import {
+	findFunctionLikeDeclaration,
+	type FunctionLikeWithParameters,
+	getAllRelatedFunctionDeclarations,
+} from "./find-function-declaration";
+import type {
+	ChangeSignatureOperation,
+	ChangeSignatureParams,
+	ChangeSignatureResult,
+} from "./types";
+
+interface CallSitePlan {
+	call: CallExpression;
+	newArgTexts: string[];
+}
+
+/**
+ * 関数のシグネチャ (パラメータの追加/削除/並び替え) を変更し、
+ * プロジェクト全体の呼び出し箇所も同期して更新する。
+ *
+ * tsconfigPath からプロジェクトを初期化して `changeSignatureOnProject` に委譲する。
+ * テストなど既存の Project に対して実行したい場合は `changeSignatureOnProject` を直接使う。
+ */
+export async function changeSignature(
+	params: ChangeSignatureParams,
+): Promise<ChangeSignatureResult> {
+	const project = initializeProject(params.tsconfigPath);
+	return changeSignatureOnProject(project, params);
+}
+
+/**
+ * 既存の Project に対して signature 変更を適用する内部 API。
+ */
+export async function changeSignatureOnProject(
+	project: Project,
+	{
+		targetFilePath,
+		position,
+		functionName,
+		changes,
+		dryRun = false,
+	}: Omit<ChangeSignatureParams, "tsconfigPath">,
+): Promise<ChangeSignatureResult> {
+	logger.debug(
+		{
+			targetFilePath,
+			position,
+			functionName,
+			changeCount: changes.length,
+			dryRun,
+		},
+		"changeSignature 開始",
+	);
+
+	if (changes.length === 0) {
+		throw new Error("changes 配列が空です");
+	}
+
+	const identifier = findIdentifierNode(project, targetFilePath, position);
+	validateSymbol(identifier, functionName);
+
+	const primary = findFunctionLikeDeclaration(identifier);
+	const allDeclarations = getAllRelatedFunctionDeclarations(primary);
+	logger.debug(
+		{ declarationCount: allDeclarations.length },
+		"対象関数宣言を解決",
+	);
+
+	// 呼び出し位置を抽出
+	const references = identifier.findReferencesAsNodes();
+	const callSites = filterCallSites(references);
+	logger.debug({ callSiteCount: callSites.length }, "呼び出し位置を抽出");
+
+	// SpreadElement を含む呼び出しは静的に置換できないため検出する。
+	// (引数を変更する operation がある場合のみ問題になる)
+	const operationsTouchCallers = changes.some((op) => {
+		if (op.kind === "add") return op.argumentForCallers !== undefined;
+		return true; // remove / reorder は必ず引数に影響
+	});
+	if (operationsTouchCallers) {
+		const spreadCalls = callSites.filter(callHasSpreadArgument);
+		if (spreadCalls.length > 0) {
+			const samples = spreadCalls
+				.slice(0, 3)
+				.map((c) => {
+					const sf = c.getSourceFile();
+					const { line, column } = sf.getLineAndColumnAtPos(c.getStart());
+					return `  - ${sf.getFilePath()}:${line}:${column}`;
+				})
+				.join("\n");
+			throw new Error(
+				`スプレッド引数 (...args) を含む呼び出しがあり、安全に書き換えできません:\n${samples}`,
+			);
+		}
+	}
+
+	// --- Phase 1: 計画フェーズ (mutation せずに新しい引数列とパラメータ列を計算) ---
+	// ここで例外が出ても in-memory project には一切手を付けていないので安全。
+	// オーバーロードシグネチャごとに型注釈が異なるので、宣言ごとに個別に計算する。
+	const declarationPlans = allDeclarations.map((decl) => ({
+		decl,
+		newParameterStructures: buildNewParameterStructures(decl, changes),
+	}));
+	const callSitePlans = planCallSiteRewrites(callSites, changes);
+
+	logger.debug(
+		{
+			declarationCount: declarationPlans.length,
+			callSitePlanCount: callSitePlans.length,
+		},
+		"計画フェーズ完了",
+	);
+
+	// --- Phase 2: 適用フェーズ (例外が起きないことを期待) ---
+	for (const plan of callSitePlans) {
+		rewriteCallArguments(plan.call, plan.newArgTexts);
+	}
+	for (const { decl, newParameterStructures } of declarationPlans) {
+		rewriteParameters(decl, newParameterStructures);
+	}
+
+	const changedFiles = getChangedFiles(project).map((sf) => sf.getFilePath());
+	logger.debug({ changedFileCount: changedFiles.length }, "適用フェーズ完了");
+
+	if (!dryRun) {
+		await saveProjectChanges(project);
+		logger.info(
+			{ functionName, changedFileCount: changedFiles.length },
+			"changeSignature 保存完了",
+		);
+	}
+	return { changedFiles };
+}
+
+function buildNewParameterStructures(
+	fn: FunctionLikeWithParameters,
+	operations: readonly ChangeSignatureOperation[],
+): OptionalKind<ParameterDeclarationStructure>[] {
+	const currentStructures: OptionalKind<ParameterDeclarationStructure>[] = fn
+		.getParameters()
+		.map((p) => {
+			const structure = p.getStructure();
+			return {
+				name: typeof structure.name === "string" ? structure.name : p.getName(),
+				type: typeof structure.type === "string" ? structure.type : undefined,
+				hasQuestionToken: structure.hasQuestionToken,
+				initializer:
+					typeof structure.initializer === "string"
+						? structure.initializer
+						: undefined,
+				isRestParameter: structure.isRestParameter,
+				isReadonly: structure.isReadonly,
+				scope: structure.scope,
+				decorators: structure.decorators,
+			};
+		});
+	return computeNewParameterStructures(currentStructures, operations);
+}
+
+function planCallSiteRewrites(
+	callSites: readonly CallExpression[],
+	operations: readonly ChangeSignatureOperation[],
+): CallSitePlan[] {
+	const plans: CallSitePlan[] = [];
+	for (const call of callSites) {
+		const argTexts = call.getArguments().map((a) => a.getText());
+		try {
+			const newArgTexts = computeNewArgumentTexts(argTexts, operations);
+			plans.push({ call, newArgTexts });
+		} catch (error) {
+			const sf = call.getSourceFile();
+			const { line, column } = sf.getLineAndColumnAtPos(call.getStart());
+			const baseMessage =
+				error instanceof Error ? error.message : String(error);
+			throw new Error(
+				`呼び出し位置 ${sf.getFilePath()}:${line}:${column} で操作を適用できませんでした: ${baseMessage}`,
+			);
+		}
+	}
+	return plans;
+}

--- a/src/ts-morph/change-signature/find-call-sites.ts
+++ b/src/ts-morph/change-signature/find-call-sites.ts
@@ -1,0 +1,53 @@
+import { type CallExpression, type Identifier, Node } from "ts-morph";
+
+/**
+ * Identifier がコール式の callee 位置にあるか判定し、該当する CallExpression を返す。
+ * 該当しない場合 (代入先、型注釈、コメントなど) は undefined。
+ *
+ * 対応する形:
+ *   foo()                       -> identifier 'foo' の親が CallExpression
+ *   obj.foo()                   -> identifier 'foo' の親が PropertyAccess、その親が CallExpression
+ *   obj?.foo()                  -> PropertyAccess (optional chain) を経由
+ *   a.b.foo()                   -> 連鎖した PropertyAccess を遡る
+ */
+export function getEnclosingCallExpression(
+	identifier: Identifier,
+): CallExpression | undefined {
+	let current: Node = identifier;
+
+	while (true) {
+		const parent = current.getParent();
+		if (!parent) return undefined;
+
+		if (Node.isPropertyAccessExpression(parent)) {
+			// identifier がプロパティ名 (右側) であれば PropertyAccess に登っていく
+			if (parent.getNameNode() === current) {
+				current = parent;
+				continue;
+			}
+			return undefined;
+		}
+
+		if (Node.isCallExpression(parent)) {
+			if (parent.getExpression() === current) {
+				return parent;
+			}
+			return undefined;
+		}
+
+		return undefined;
+	}
+}
+
+/**
+ * 参照 Node 群から呼び出し式のみを抽出する
+ */
+export function filterCallSites(references: Node[]): CallExpression[] {
+	const calls: CallExpression[] = [];
+	for (const ref of references) {
+		if (!Node.isIdentifier(ref)) continue;
+		const call = getEnclosingCallExpression(ref);
+		if (call) calls.push(call);
+	}
+	return calls;
+}

--- a/src/ts-morph/change-signature/find-function-declaration.ts
+++ b/src/ts-morph/change-signature/find-function-declaration.ts
@@ -1,0 +1,107 @@
+import { type Identifier, Node, type ParameteredNode } from "ts-morph";
+
+/** パラメータリストを持つ関数様ノード */
+export type FunctionLikeWithParameters = Node & ParameteredNode;
+
+/**
+ * Identifier から所属する関数様宣言 (FunctionDeclaration / MethodDeclaration /
+ * ArrowFunction / FunctionExpression / GetAccessor / SetAccessor) を取得する。
+ */
+export function findFunctionLikeDeclaration(
+	identifier: Identifier,
+): FunctionLikeWithParameters {
+	const parent = identifier.getParent();
+	if (!parent) {
+		throw new Error("Identifier has no parent");
+	}
+
+	if (
+		Node.isFunctionDeclaration(parent) &&
+		parent.getNameNode() === identifier
+	) {
+		return parent;
+	}
+	if (Node.isMethodDeclaration(parent) && parent.getNameNode() === identifier) {
+		return parent;
+	}
+	if (Node.isMethodSignature(parent) && parent.getNameNode() === identifier) {
+		return parent;
+	}
+	if (
+		Node.isGetAccessorDeclaration(parent) &&
+		parent.getNameNode() === identifier
+	) {
+		return parent;
+	}
+	if (
+		Node.isSetAccessorDeclaration(parent) &&
+		parent.getNameNode() === identifier
+	) {
+		return parent;
+	}
+	if (
+		Node.isFunctionExpression(parent) &&
+		parent.getNameNode() === identifier
+	) {
+		return parent;
+	}
+
+	// const foo = () => {} / const foo = function() {}
+	if (
+		Node.isVariableDeclaration(parent) &&
+		parent.getNameNode() === identifier
+	) {
+		const initializer = parent.getInitializer();
+		if (
+			initializer &&
+			(Node.isArrowFunction(initializer) ||
+				Node.isFunctionExpression(initializer))
+		) {
+			return initializer;
+		}
+	}
+
+	// foo: () => {}  (property assignment in object literal)
+	if (
+		Node.isPropertyAssignment(parent) &&
+		parent.getNameNode() === identifier
+	) {
+		const initializer = parent.getInitializer();
+		if (
+			initializer &&
+			(Node.isArrowFunction(initializer) ||
+				Node.isFunctionExpression(initializer))
+		) {
+			return initializer;
+		}
+	}
+
+	const parentKind = parent.getKindName();
+	throw new Error(
+		`指定位置のシンボル '${identifier.getText()}' は関数宣言/メソッド/関数式ではありません (検出した親ノード種別: ${parentKind})。コンストラクタは対象外です。パラメータ自体やインポート位置を指していないか確認してください。`,
+	);
+}
+
+/**
+ * オーバーロード関数/メソッドの場合、関連する全宣言 (overload signature + implementation)
+ * を返す。そうでなければ受け取った宣言だけを単独で返す。
+ *
+ * これにより `change_signature` 適用時にオーバーロードシグネチャの片方だけが
+ * 変更されて型不整合になるのを防ぐ。
+ */
+export function getAllRelatedFunctionDeclarations(
+	fn: FunctionLikeWithParameters,
+): FunctionLikeWithParameters[] {
+	if (Node.isFunctionDeclaration(fn) || Node.isMethodDeclaration(fn)) {
+		const implementation = fn.isImplementation() ? fn : fn.getImplementation();
+		if (implementation) {
+			const overloads = implementation.getOverloads();
+			if (overloads.length > 0) {
+				return [...overloads, implementation];
+			}
+		}
+		// オーバーロード無しでも getOverloads() を呼ぶことで MethodSignature の
+		// 重複定義などには対応できないが、それは想定外。
+	}
+	return [fn];
+}

--- a/src/ts-morph/change-signature/types.ts
+++ b/src/ts-morph/change-signature/types.ts
@@ -1,0 +1,43 @@
+export type ChangeSignatureOperation =
+	| {
+			kind: "add";
+			/** 挿入位置 (0-based)。省略時は末尾。 */
+			index?: number;
+			/** 追加するパラメータ名 */
+			name: string;
+			/** パラメータの型注釈テキスト (例: "string", "{ id: number }")。省略時は型注釈なし。 */
+			typeText?: string;
+			/** パラメータをオプショナル (`?`) にするか */
+			optional?: boolean;
+			/** デフォルト値テキスト (例: "0", '"hello"") */
+			defaultValue?: string;
+			/**
+			 * 既存の呼び出し側に挿入する引数式テキスト。
+			 * - 省略時はデフォルト値があればそれを使用、なければ呼び出し側に何も挿入しない (末尾追加かつオプショナル/デフォルトあり前提)。
+			 * - 既存呼び出しに新しい引数が必要な場合は明示的に指定すること。
+			 */
+			argumentForCallers?: string;
+	  }
+	| {
+			kind: "remove";
+			/** 削除するパラメータの index (0-based) */
+			index: number;
+	  }
+	| {
+			kind: "reorder";
+			/** 新しい順序。例: [2, 0, 1] は newParams[0] = oldParams[2] を意味する。長さは現在のパラメータ数と一致する必要がある。 */
+			newOrder: number[];
+	  };
+
+export interface ChangeSignatureParams {
+	tsconfigPath: string;
+	targetFilePath: string;
+	position: { line: number; column: number };
+	functionName: string;
+	changes: ChangeSignatureOperation[];
+	dryRun?: boolean;
+}
+
+export interface ChangeSignatureResult {
+	changedFiles: string[];
+}


### PR DESCRIPTION
## Summary
- issue #37 の `change_signature` を実装。関数/メソッド/アロー関数/accessor のパラメータ追加・削除・並び替えを、プロジェクト全体の呼び出し箇所に同期して適用する MCP ツール。
- 操作は `add` / `remove` / `reorder` を 1 リクエストで順次適用可能。後段の操作は前段の結果を見る。
- ts-morph の TypeChecker と参照解析を使うため、LLM 単独編集で起こる「呼び出し漏れ」「リネーム取りこぼし」を構造的に防ぐ。

## 安全性設計
- **オーバーロード**: 該当する全 signature + implementation を同時更新 (型注釈は宣言ごとに保持)
- **スプレッド呼び出し**: `fn(...args)` を含む呼び出しが 1 つでもあり、引数を変更する操作があれば即失敗
- **2 フェーズ実行 (plan → apply)**: 全 call site と全宣言の new structures を mutation せずに先に計算 → 全検証通過後に書き換え。検証エラー時には in-memory も無変更
- **rest パラメータ**: 操作後に末尾以外に来る配置 (`(...rest, b)` 等) を事前に拒否
- **`add` の caller 整合性**:
  - 中間挿入 (index < params.length) は `argumentForCallers` 必須
  - 末尾追加でも optional/default が無い場合は `argumentForCallers` 必須
  - `argumentForCallers` で要求 index が呼び出しの引数数を超える場合 (省略 optional がある呼び出し等) も失敗
- **対応宣言種別**: FunctionDeclaration / MethodDeclaration / MethodSignature / GetAccessor / SetAccessor / FunctionExpression / アロー関数代入 / PropertyAssignment 内の関数式

## 構成
- `src/ts-morph/change-signature/`:
  - `types.ts` — 操作型定義
  - `find-function-declaration.ts` — 関数様宣言の解決 + オーバーロード収集
  - `find-call-sites.ts` — 参照から呼び出し位置のみを抽出
  - `apply-changes.ts` — 純粋関数群 (parameter / argument の new array 計算 + rest 検証 + spread 検出)
  - `change-signature.ts` — オーケストレーション (`changeSignature(params)` / `changeSignatureOnProject(project, params)`)
- `src/mcp/tools/register-change-signature-tool.ts` — Zod スキーマと LLM 向け description
- `ts-morph-tools.ts` に登録、`integration.test.ts` に統合テスト追加

## Test plan
- [x] ユニット 21 + 統合 13 + MCP 統合 2 で計 36 ケース。プロジェクト全体 274 tests / 1 skipped 通過
- [x] `pnpm check-types` / `pnpm lint` / `pnpm format` クリーン
- [x] 主要シナリオを in-memory project で検証:
  - [x] 末尾デフォルト値追加で呼び出し側無変更
  - [x] 先頭必須追加で全呼び出し更新
  - [x] remove / reorder
  - [x] メソッド呼び出し (`obj.foo()`)
  - [x] オーバーロード全宣言の同時更新
  - [x] スプレッド呼び出し検出時に部分適用しないこと
  - [x] 引数数不一致の reorder で部分適用しないこと
  - [x] 中間 add / 末尾 add (optional/default 無し) で `argumentForCallers` 必須
  - [x] rest パラメータの中間配置を `add` / `reorder` 双方で拒否
  - [x] GetAccessor / SetAccessor の取得
  - [x] 関数でない位置 (parameter) を指したときに親ノード種別を含むエラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)