### PR TITLE
feat(get-type-at-position): 任意位置の型・シンボル情報を取得する MCP ツール

### DIFF
--- a/src/mcp/tools/integration.test.ts
+++ b/src/mcp/tools/integration.test.ts
@@ -440,6 +440,107 @@ foo(1);
 		});
 	});
 
+	describe("get_type_at_position_by_tsmorph", () => {
+		it("変数の型情報を取得できる", async () => {
+			const filePath = path.join(srcDir, "types.ts");
+			fs.writeFileSync(
+				filePath,
+				`const user = { id: "u1", name: "alice" };
+console.log(user);
+`,
+			);
+
+			const result = await mockServer.callTool(
+				"get_type_at_position_by_tsmorph",
+				{
+					tsconfigPath,
+					targetFilePath: filePath,
+					position: { line: 2, column: 13 }, // "user" inside console.log
+				},
+			);
+
+			expect(result).toHaveProperty("isError", false);
+			const text = result.content[0]?.text || "";
+			expect(text).toContain("Type:");
+			expect(text).toContain("id: string");
+			expect(text).toContain("name: string");
+			expect(text).toContain("Symbol: user (VariableDeclaration)");
+			expect(text).toContain(`Declared at: ${filePath}:1:`);
+		});
+
+		it("関数のシグネチャを call style で展開する", async () => {
+			const filePath = path.join(srcDir, "fn.ts");
+			fs.writeFileSync(
+				filePath,
+				`function greet(name: string): string {
+  return "hello " + name;
+}
+greet("world");
+`,
+			);
+
+			const result = await mockServer.callTool(
+				"get_type_at_position_by_tsmorph",
+				{
+					tsconfigPath,
+					targetFilePath: filePath,
+					position: { line: 4, column: 1 },
+				},
+			);
+
+			expect(result).toHaveProperty("isError", false);
+			const text = result.content[0]?.text || "";
+			expect(text).toContain("(name: string) => string");
+		});
+
+		it("import された symbol の宣言位置は元ファイル", async () => {
+			const libPath = path.join(srcDir, "lib.ts");
+			const appPath = path.join(srcDir, "app.ts");
+			fs.writeFileSync(
+				libPath,
+				`export function helper(n: number): string { return String(n); }
+`,
+			);
+			fs.writeFileSync(
+				appPath,
+				`import { helper } from "./lib";
+helper(1);
+`,
+			);
+
+			const result = await mockServer.callTool(
+				"get_type_at_position_by_tsmorph",
+				{
+					tsconfigPath,
+					targetFilePath: appPath,
+					position: { line: 2, column: 1 },
+				},
+			);
+
+			expect(result).toHaveProperty("isError", false);
+			const text = result.content[0]?.text || "";
+			expect(text).toContain("Symbol: helper");
+			expect(text).toContain(`Declared at: ${libPath}:1:`);
+		});
+
+		it("範囲外の位置でエラー", async () => {
+			const filePath = path.join(srcDir, "small.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+
+			const result = await mockServer.callTool(
+				"get_type_at_position_by_tsmorph",
+				{
+					tsconfigPath,
+					targetFilePath: filePath,
+					position: { line: 99, column: 1 },
+				},
+			);
+
+			expect(result).toHaveProperty("isError", true);
+			expect(result.content[0]?.text).toContain("Error");
+		});
+	});
+
 	describe("エラーハンドリング", () => {
 		it("存在しないファイルに対してエラーを返す", async () => {
 			const nonExistentPath = path.join(srcDir, "non-existent.ts");

--- a/src/mcp/tools/register-get-type-at-position-tool.ts
+++ b/src/mcp/tools/register-get-type-at-position-tool.ts
@@ -5,6 +5,29 @@ import { initializeProject } from "../../ts-morph/_utils/ts-morph-project";
 import { getTypeAtPosition } from "../../ts-morph/get-type-at-position/get-type-at-position";
 import logger from "../../utils/logger";
 
+/**
+ * logger 自体が例外を投げる (LOG_OUTPUT=file でディスクフル等) ケースでも、
+ * MCP レスポンス生成が阻まれないようにラップする。
+ */
+function safeLogError(error: unknown, toolArgs: Record<string, unknown>): void {
+	try {
+		logger.error(
+			{ err: error, toolArgs },
+			"Error executing get_type_at_position_by_tsmorph",
+		);
+	} catch (loggerErr) {
+		console.error("Failed to write error log:", loggerErr);
+	}
+}
+
+function safeLogInfo(fields: Record<string, unknown>): void {
+	try {
+		logger.info(fields, "get_type_at_position_by_tsmorph tool finished");
+	} catch (loggerErr) {
+		console.error("Failed to write info log:", loggerErr);
+	}
+}
+
 export function registerGetTypeAtPositionTool(server: McpServer): void {
 	server.tool(
 		"get_type_at_position_by_tsmorph",
@@ -22,8 +45,10 @@ export function registerGetTypeAtPositionTool(server: McpServer): void {
 ## Critical constraints
 - \`position\` is 1-based (line/column), matching what editors display.
 - All paths (\`tsconfigPath\`, \`targetFilePath\`) MUST be absolute.
-- For function-like identifiers the type is expanded to call-style \`(arg: T) => R\` form rather than the \`typeof Foo\` shorthand. Overloads are joined with \`&\`.
-- For imported symbols, the resolved (aliased) symbol's declaration location is reported, not the local import binding.
+- For function/method identifiers (where ALL declarations are signature-bearing) the type is rendered as a call-style \`(arg: T) => R\` text taken directly from the declaration source, preserving rest \`...\`, optional \`?\`, default values, and destructuring patterns. Overloads are joined with \`&\` and the implementation signature is hidden.
+- For function/namespace merges or other mixed symbols (function with extra properties), the raw TypeChecker text (e.g. \`typeof fn\`) is returned to avoid silently dropping the property side of the type.
+- For imported symbols the resolved (aliased) symbol's declaration location is reported, including barrel re-export chains (\`export * from\`, \`export { x } from\`) which are recursively unwrapped.
+- For built-in or third-party symbols (e.g. \`console\`, \`Promise\`), \`declaration\` may point inside \`node_modules\` lib.d.ts files.
 
 ## Result fields
 - \`type\`: the inferred type text.
@@ -32,7 +57,8 @@ export function registerGetTypeAtPositionTool(server: McpServer): void {
 - \`declaration\` (optional): file path + 1-based line/column of the first declaration.
 
 ## Tips
-- Pointing at whitespace or a comment line returns a SourceFile/EndOfFileToken node and the file-level inferred type — usually not what you want. Re-target the position to the identifier.`,
+- Pointing at whitespace or a comment line returns a SourceFile/EndOfFileToken node and the file-level inferred type (e.g. \`typeof import("...")\`) — this is NOT an error but is usually not what you want. Check \`nodeKind\` in the response and re-target to the identifier.
+- For function/namespace merges where the type returns as \`typeof fn\`, inspect the \`declaration\` location to discover the merged namespace members.`,
 		{
 			tsconfigPath: z
 				.string()
@@ -84,10 +110,7 @@ export function registerGetTypeAtPositionTool(server: McpServer): void {
 				}
 				message = lines.join("\n");
 			} catch (error) {
-				logger.error(
-					{ err: error, toolArgs: logArgs },
-					"Error executing get_type_at_position_by_tsmorph",
-				);
+				safeLogError(error, logArgs);
 				const errorMessage =
 					error instanceof Error ? error.message : String(error);
 				message = `Error: ${errorMessage}`;
@@ -95,14 +118,11 @@ export function registerGetTypeAtPositionTool(server: McpServer): void {
 			} finally {
 				const endTime = performance.now();
 				duration = ((endTime - startTime) / 1000).toFixed(2);
-				logger.info(
-					{
-						status: isError ? "Failure" : "Success",
-						durationMs: Number.parseFloat((endTime - startTime).toFixed(2)),
-						...logArgs,
-					},
-					"get_type_at_position_by_tsmorph tool finished",
-				);
+				safeLogInfo({
+					status: isError ? "Failure" : "Success",
+					durationMs: Number.parseFloat((endTime - startTime).toFixed(2)),
+					...logArgs,
+				});
 				try {
 					logger.flush();
 				} catch (flushErr) {

--- a/src/mcp/tools/register-get-type-at-position-tool.ts
+++ b/src/mcp/tools/register-get-type-at-position-tool.ts
@@ -1,0 +1,123 @@
+import { performance } from "node:perf_hooks";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { initializeProject } from "../../ts-morph/_utils/ts-morph-project";
+import { getTypeAtPosition } from "../../ts-morph/get-type-at-position/get-type-at-position";
+import logger from "../../utils/logger";
+
+export function registerGetTypeAtPositionTool(server: McpServer): void {
+	server.tool(
+		"get_type_at_position_by_tsmorph",
+		`[ts-morph] Return the TypeChecker-inferred type at a specific position in a TypeScript/JavaScript file, plus the symbol and its declaration location.
+
+## When to use
+- Quickly verifying "what is the actual inferred type of this variable / expression / function?" without spawning \`tsc\` or running a full type check.
+- Cheaper than \`Read\`-ing the declaration file when all you need is the type signature.
+- Before refactoring, to confirm what a value's actual shape is (especially helpful when types are inferred through multiple generics).
+
+## When NOT to use
+- Bulk type analysis across many positions — call \`tsc\` directly instead.
+- Listing every reference of a symbol — use \`find_references_by_tsmorph\`.
+
+## Critical constraints
+- \`position\` is 1-based (line/column), matching what editors display.
+- All paths (\`tsconfigPath\`, \`targetFilePath\`) MUST be absolute.
+- For function-like identifiers the type is expanded to call-style \`(arg: T) => R\` form rather than the \`typeof Foo\` shorthand. Overloads are joined with \`&\`.
+- For imported symbols, the resolved (aliased) symbol's declaration location is reported, not the local import binding.
+
+## Result fields
+- \`type\`: the inferred type text.
+- \`nodeKind\` / \`nodeText\`: what the position landed on (Identifier, StringLiteral, etc., and the source text — truncated to 80 chars).
+- \`symbol\` (optional): the resolved symbol's name and the kind of its first declaration.
+- \`declaration\` (optional): file path + 1-based line/column of the first declaration.
+
+## Tips
+- Pointing at whitespace or a comment line returns a SourceFile/EndOfFileToken node and the file-level inferred type — usually not what you want. Re-target the position to the identifier.`,
+		{
+			tsconfigPath: z
+				.string()
+				.describe("Path to the project's tsconfig.json file."),
+			targetFilePath: z
+				.string()
+				.describe("Path to the file containing the position to inspect."),
+			position: z
+				.object({
+					line: z.number().int().positive().describe("1-based line number."),
+					column: z
+						.number()
+						.int()
+						.positive()
+						.describe("1-based column number."),
+				})
+				.describe("Exact position to inspect."),
+		},
+		async (args) => {
+			const startTime = performance.now();
+			let message = "";
+			let isError = false;
+			let duration = "0.00";
+
+			const logArgs = {
+				targetFilePath: args.targetFilePath,
+				position: args.position,
+			};
+
+			try {
+				const project = initializeProject(args.tsconfigPath);
+				const result = getTypeAtPosition(
+					project,
+					args.targetFilePath,
+					args.position,
+				);
+
+				const lines: string[] = [
+					`Type: ${result.type}`,
+					`Node: ${result.nodeKind} ${JSON.stringify(result.nodeText)}`,
+				];
+				if (result.symbol) {
+					lines.push(`Symbol: ${result.symbol.name} (${result.symbol.kind})`);
+				}
+				if (result.declaration) {
+					lines.push(
+						`Declared at: ${result.declaration.filePath}:${result.declaration.line}:${result.declaration.column}`,
+					);
+				}
+				message = lines.join("\n");
+			} catch (error) {
+				logger.error(
+					{ err: error, toolArgs: logArgs },
+					"Error executing get_type_at_position_by_tsmorph",
+				);
+				const errorMessage =
+					error instanceof Error ? error.message : String(error);
+				message = `Error: ${errorMessage}`;
+				isError = true;
+			} finally {
+				const endTime = performance.now();
+				duration = ((endTime - startTime) / 1000).toFixed(2);
+				logger.info(
+					{
+						status: isError ? "Failure" : "Success",
+						durationMs: Number.parseFloat((endTime - startTime).toFixed(2)),
+						...logArgs,
+					},
+					"get_type_at_position_by_tsmorph tool finished",
+				);
+				try {
+					logger.flush();
+				} catch (flushErr) {
+					console.error("Failed to flush logs:", flushErr);
+				}
+			}
+
+			const finalMessage = `${message}\nStatus: ${
+				isError ? "Failure" : "Success"
+			}\nProcessing time: ${duration} seconds`;
+
+			return {
+				content: [{ type: "text", text: finalMessage }],
+				isError,
+			};
+		},
+	);
+}

--- a/src/mcp/tools/ts-morph-tools.ts
+++ b/src/mcp/tools/ts-morph-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { registerChangeSignatureTool } from "./register-change-signature-tool";
 import { registerFindReferencesTool } from "./register-find-references-tool";
+import { registerGetTypeAtPositionTool } from "./register-get-type-at-position-tool";
 import { registerMoveSymbolToFileTool } from "./register-move-symbol-to-file-tool";
 import { registerRemovePathAliasTool } from "./register-remove-path-alias-tool";
 import { registerRenameFileSystemEntryTool } from "./register-rename-file-system-entry-tool";
@@ -17,4 +18,5 @@ export function registerTsMorphTools(server: McpServer): void {
 	registerRemovePathAliasTool(server);
 	registerMoveSymbolToFileTool(server);
 	registerChangeSignatureTool(server);
+	registerGetTypeAtPositionTool(server);
 }

--- a/src/ts-morph/get-type-at-position/get-type-at-position.test.ts
+++ b/src/ts-morph/get-type-at-position/get-type-at-position.test.ts
@@ -1,0 +1,213 @@
+import type { Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import { createInMemoryProject } from "../_test-utils/create-in-memory-project";
+import { getTypeAtPosition } from "./get-type-at-position";
+
+function setup(files: Record<string, string>): Project {
+	const project = createInMemoryProject();
+	for (const [path, content] of Object.entries(files)) {
+		project.createSourceFile(path, content, { overwrite: true });
+	}
+	return project;
+}
+
+describe("getTypeAtPosition", () => {
+	describe("基本", () => {
+		it("変数識別子の型を取得できる", () => {
+			const project = setup({
+				"/a.ts": [
+					'const user = { id: "u1", name: "alice" };',
+					"console.log(user);",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 13,
+			});
+			expect(result.nodeKind).toBe("Identifier");
+			expect(result.nodeText).toBe("user");
+			expect(result.type).toBe("{ id: string; name: string; }");
+			expect(result.symbol).toEqual({
+				name: "user",
+				kind: "VariableDeclaration",
+			});
+			expect(result.declaration?.filePath).toBe("/a.ts");
+			expect(result.declaration?.line).toBe(1);
+		});
+
+		it("関数識別子の型 (シグネチャ) を取得できる", () => {
+			const project = setup({
+				"/a.ts": [
+					"function greet(name: string): string {",
+					'  return "hello " + name;',
+					"}",
+					"greet('world');",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 4,
+				column: 1,
+			});
+			expect(result.nodeKind).toBe("Identifier");
+			expect(result.type).toContain("(name: string)");
+			expect(result.type).toContain("string");
+			expect(result.symbol).toEqual({
+				name: "greet",
+				kind: "FunctionDeclaration",
+			});
+		});
+
+		it("プロパティアクセスのプロパティ部分の型を取得できる", () => {
+			const project = setup({
+				"/a.ts": [
+					'const user = { id: 42, name: "alice" };',
+					"const x = user.name;",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 16, // "name" in user.name
+			});
+			expect(result.nodeKind).toBe("Identifier");
+			expect(result.nodeText).toBe("name");
+			expect(result.type).toBe("string");
+		});
+
+		it("関数呼び出し結果は呼び出された関数識別子位置で関数の型として返す", () => {
+			const project = setup({
+				"/a.ts": [
+					"function getNumber(): number { return 1; }",
+					"const x = getNumber();",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 11, // "getNumber" identifier
+			});
+			expect(result.type).toContain("() => number");
+		});
+	});
+
+	describe("リテラル", () => {
+		it("文字列リテラルの位置で string リテラル型を返す", () => {
+			const project = setup({
+				"/a.ts": 'const x = "hello";',
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 1,
+				column: 12, // inside "hello"
+			});
+			expect(result.nodeKind).toBe("StringLiteral");
+			expect(result.type).toBe('"hello"');
+		});
+
+		it("数値リテラルの位置で number リテラル型を返す", () => {
+			const project = setup({
+				"/a.ts": "const x = 42;",
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 1,
+				column: 11,
+			});
+			expect(result.nodeKind).toBe("NumericLiteral");
+			expect(result.type).toBe("42");
+		});
+	});
+
+	describe("import された symbol", () => {
+		it("別ファイルで宣言されたシンボルの宣言位置を含む結果を返す", () => {
+			const project = setup({
+				"/lib.ts":
+					"export function helper(n: number): string { return String(n); }",
+				"/a.ts": ['import { helper } from "./lib";', "helper(1);"].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 1,
+			});
+			expect(result.symbol?.name).toBe("helper");
+			expect(result.declaration?.filePath).toBe("/lib.ts");
+			expect(result.declaration?.line).toBe(1);
+		});
+	});
+
+	describe("ジェネリック", () => {
+		it("ユーザ定義ジェネリック型も復元できる", () => {
+			const project = setup({
+				"/a.ts": [
+					"type Box<T> = { value: T };",
+					'const b: Box<string> = { value: "hi" };',
+					"const v = b;",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 3,
+				column: 11,
+			});
+			expect(result.type).toBe("Box<string>");
+		});
+
+		it("ユニオン型を保持する", () => {
+			const project = setup({
+				"/a.ts": [
+					"function f(): string | number { return 1; }",
+					"const v = f();",
+					"const w = v;",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 3,
+				column: 11,
+			});
+			expect(result.type).toBe("string | number");
+		});
+	});
+
+	describe("エラー処理", () => {
+		it("存在しないファイルでエラー", () => {
+			const project = setup({});
+			expect(() =>
+				getTypeAtPosition(project, "/nonexistent.ts", {
+					line: 1,
+					column: 1,
+				}),
+			).toThrow(/ファイルが見つかりません/);
+		});
+
+		it("ファイル範囲外の位置でエラー", () => {
+			const project = setup({ "/a.ts": "const x = 1;" });
+			expect(() =>
+				getTypeAtPosition(project, "/a.ts", { line: 99, column: 1 }),
+			).toThrow(/範囲外/);
+		});
+
+		it("末尾の空白行に対しても型情報を返す (SourceFile 全体の型)", () => {
+			// getDescendantAtPos は空白でも SourceFile を返すため、エラーにはならない。
+			// ただし結果の nodeKind を見れば呼び出し側で判定可能。
+			const project = setup({ "/a.ts": "const x = 1;\n\n" });
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 1,
+			});
+			// 空白上だと EndOfFileToken や SourceFile になることがある
+			expect(["SourceFile", "EndOfFileToken"]).toContain(result.nodeKind);
+		});
+	});
+
+	describe("型注釈位置", () => {
+		it("型エイリアス使用位置の型 (引数の型注釈) を取得できる", () => {
+			const project = setup({
+				"/a.ts": [
+					"type UserId = string;",
+					"function f(id: UserId) { return id; }",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 16, // "UserId" in type annotation
+			});
+			expect(result.symbol?.name).toBe("UserId");
+			expect(result.symbol?.kind).toBe("TypeAliasDeclaration");
+		});
+	});
+});

--- a/src/ts-morph/get-type-at-position/get-type-at-position.test.ts
+++ b/src/ts-morph/get-type-at-position/get-type-at-position.test.ts
@@ -49,8 +49,7 @@ describe("getTypeAtPosition", () => {
 				column: 1,
 			});
 			expect(result.nodeKind).toBe("Identifier");
-			expect(result.type).toContain("(name: string)");
-			expect(result.type).toContain("string");
+			expect(result.type).toBe("(name: string) => string");
 			expect(result.symbol).toEqual({
 				name: "greet",
 				kind: "FunctionDeclaration",
@@ -82,9 +81,95 @@ describe("getTypeAtPosition", () => {
 			});
 			const result = getTypeAtPosition(project, "/a.ts", {
 				line: 2,
-				column: 11, // "getNumber" identifier
+				column: 11,
 			});
-			expect(result.type).toContain("() => number");
+			expect(result.type).toBe("() => number");
+		});
+	});
+
+	describe("関数 signature の修飾子保持", () => {
+		it("rest パラメータの `...` を保持する", () => {
+			const project = setup({
+				"/a.ts": [
+					"function f(a: number, ...rest: number[]): void {}",
+					"f(1, 2, 3);",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 1,
+			});
+			expect(result.type).toBe("(a: number, ...rest: number[]) => void");
+		});
+
+		it("optional `?` を保持する", () => {
+			const project = setup({
+				"/a.ts": ["function f(a: number, b?: string): void {}", "f(1);"].join(
+					"\n",
+				),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 1,
+			});
+			expect(result.type).toBe("(a: number, b?: string) => void");
+		});
+
+		it("分割代入パラメータが `__0` ではなく元のテキストで保持される", () => {
+			const project = setup({
+				"/a.ts": [
+					"function f({ a, b }: { a: number; b: string }): void {}",
+					"f({ a: 1, b: 'x' });",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 1,
+			});
+			// __0 のような合成名が露出しないこと
+			expect(result.type).not.toContain("__0");
+			expect(result.type).toContain("{ a, b }");
+			expect(result.type).toContain("a: number");
+		});
+	});
+
+	describe("オーバーロード関数", () => {
+		it("オーバーロード signature を `&` で結合して返す (implementation は隠す)", () => {
+			const project = setup({
+				"/a.ts": [
+					"function f(a: string): string;",
+					"function f(a: number): number;",
+					"function f(a: string | number) { return a; }",
+					"f('hi');",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 4,
+				column: 1,
+			});
+			expect(result.type).toBe(
+				"((a: string) => string) & ((a: number) => number)",
+			);
+		});
+	});
+
+	describe("関数 + namespace マージ", () => {
+		it("namespace 側のプロパティを保つために signature 形に展開しない", () => {
+			const project = setup({
+				"/a.ts": [
+					"function fn(x: number): string { return ''; }",
+					"namespace fn { export const version = '1.0'; }",
+					"const ref = fn;",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 3,
+				column: 13,
+			});
+			// signature 展開してしまうと "(x: number) => string" となり namespace 側 (version) が消える。
+			// TS が返す `typeof fn` のまま保ち、エージェントが宣言を辿れるようにする。
+			expect(result.type).not.toMatch(/^\(x: number\) => string$/);
+			expect(result.type).toBe("typeof fn");
 		});
 	});
 
@@ -114,8 +199,8 @@ describe("getTypeAtPosition", () => {
 		});
 	});
 
-	describe("import された symbol", () => {
-		it("別ファイルで宣言されたシンボルの宣言位置を含む結果を返す", () => {
+	describe("import alias 解決", () => {
+		it("直接 import された symbol の宣言位置を元ファイルで返す", () => {
 			const project = setup({
 				"/lib.ts":
 					"export function helper(n: number): string { return String(n); }",
@@ -128,6 +213,41 @@ describe("getTypeAtPosition", () => {
 			expect(result.symbol?.name).toBe("helper");
 			expect(result.declaration?.filePath).toBe("/lib.ts");
 			expect(result.declaration?.line).toBe(1);
+			expect(result.type).toBe("(n: number) => string");
+		});
+
+		it("barrel re-export (export * from) 越しでも元の宣言まで再帰解決する", () => {
+			const project = setup({
+				"/a.ts":
+					"export function helper(n: number): string { return String(n); }",
+				"/index.ts": 'export * from "./a";',
+				"/main.ts": ['import { helper } from "./index";', "helper(1);"].join(
+					"\n",
+				),
+			});
+			const result = getTypeAtPosition(project, "/main.ts", {
+				line: 2,
+				column: 1,
+			});
+			expect(result.symbol?.name).toBe("helper");
+			expect(result.declaration?.filePath).toBe("/a.ts");
+			expect(result.declaration?.line).toBe(1);
+		});
+
+		it("named re-export (export { x } from) 越しでも元の宣言まで再帰解決する", () => {
+			const project = setup({
+				"/a.ts":
+					"export function helper(n: number): string { return String(n); }",
+				"/index.ts": 'export { helper } from "./a";',
+				"/main.ts": ['import { helper } from "./index";', "helper(1);"].join(
+					"\n",
+				),
+			});
+			const result = getTypeAtPosition(project, "/main.ts", {
+				line: 2,
+				column: 1,
+			});
+			expect(result.declaration?.filePath).toBe("/a.ts");
 		});
 	});
 
@@ -161,6 +281,21 @@ describe("getTypeAtPosition", () => {
 			});
 			expect(result.type).toBe("string | number");
 		});
+
+		it("ジェネリック関数の signature は元の型パラメータを保持する", () => {
+			const project = setup({
+				"/a.ts": [
+					"function identity<T>(x: T): T { return x; }",
+					"identity(1);",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 2,
+				column: 1,
+			});
+			// 元の宣言から組み立てるので、推論された number ではなく T が残る
+			expect(result.type).toBe("(x: T) => T");
+		});
 	});
 
 	describe("エラー処理", () => {
@@ -181,16 +316,31 @@ describe("getTypeAtPosition", () => {
 			).toThrow(/範囲外/);
 		});
 
-		it("末尾の空白行に対しても型情報を返す (SourceFile 全体の型)", () => {
+		it("line=0 / column=0 のような不正な位置はエラー", () => {
+			const project = setup({ "/a.ts": "const x = 1;" });
+			expect(() =>
+				getTypeAtPosition(project, "/a.ts", { line: 0, column: 1 }),
+			).toThrow(/1-based/);
+			expect(() =>
+				getTypeAtPosition(project, "/a.ts", { line: 1, column: 0 }),
+			).toThrow(/1-based/);
+			expect(() =>
+				getTypeAtPosition(project, "/a.ts", { line: -1, column: 1 }),
+			).toThrow(/1-based/);
+		});
+
+		it("末尾の空白行に対しても型情報を返す (SourceFile レベルの型)", () => {
 			// getDescendantAtPos は空白でも SourceFile を返すため、エラーにはならない。
-			// ただし結果の nodeKind を見れば呼び出し側で判定可能。
+			// nodeKind と type の双方を確認することで、ts-morph のバージョン差を検出可能にする。
 			const project = setup({ "/a.ts": "const x = 1;\n\n" });
 			const result = getTypeAtPosition(project, "/a.ts", {
 				line: 2,
 				column: 1,
 			});
-			// 空白上だと EndOfFileToken や SourceFile になることがある
 			expect(["SourceFile", "EndOfFileToken"]).toContain(result.nodeKind);
+			// 空白位置でも何らかの型文字列が返ること (空文字や undefined ではない)
+			expect(typeof result.type).toBe("string");
+			expect(result.type.length).toBeGreaterThan(0);
 		});
 	});
 
@@ -208,6 +358,48 @@ describe("getTypeAtPosition", () => {
 			});
 			expect(result.symbol?.name).toBe("UserId");
 			expect(result.symbol?.kind).toBe("TypeAliasDeclaration");
+		});
+	});
+
+	describe("メソッド / accessor", () => {
+		it("インスタンスメソッド呼び出しの signature を取得できる", () => {
+			const project = setup({
+				"/a.ts": [
+					"class C {",
+					"  greet(name: string): string { return name; }",
+					"}",
+					"const c = new C();",
+					"c.greet('hi');",
+				].join("\n"),
+			});
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 5,
+				column: 3, // "greet" in c.greet(...)
+			});
+			expect(result.type).toBe("(name: string) => string");
+		});
+	});
+
+	describe("nodeText の安全な切り詰め", () => {
+		it("UTF-16 サロゲートペアを途中で切らない", () => {
+			// 79 chars + 1 emoji (= 81 code points)。コードポイント80でカットすると emoji の前で止まる。
+			const longString = `"${"a".repeat(78)}\u{1F389}xyz"`;
+			const project = setup({
+				"/a.ts": `const x = ${longString};`,
+			});
+			// 文字列リテラル本体の位置を指す
+			const result = getTypeAtPosition(project, "/a.ts", {
+				line: 1,
+				column: 11,
+			});
+			expect(result.nodeKind).toBe("StringLiteral");
+			// 切り詰めが起きていれば '…' で終わるが、孤立サロゲートが残らないこと
+			if (result.nodeText.endsWith("…")) {
+				// 末尾 '…' を取り除いた残りが well-formed UTF-16 であること
+				const body = result.nodeText.slice(0, -1);
+				// lone high surrogate の検出
+				expect(body).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+			}
 		});
 	});
 });

--- a/src/ts-morph/get-type-at-position/get-type-at-position.ts
+++ b/src/ts-morph/get-type-at-position/get-type-at-position.ts
@@ -1,4 +1,9 @@
-import type { Node, Project, Signature, Type } from "ts-morph";
+import {
+	Node,
+	type Project,
+	type Symbol as TsMorphSymbol,
+	type Type,
+} from "ts-morph";
 
 export interface Position {
 	/** 1-based 行番号 */
@@ -25,24 +30,29 @@ export interface GetTypeAtPositionResult {
 	position: Position;
 	/** その位置に存在するノードの SyntaxKind 名 */
 	nodeKind: string;
-	/** その位置のノードのソーステキスト (80 文字で切り詰め) */
+	/** その位置のノードのソーステキスト (80 コードポイントで切り詰め) */
 	nodeText: string;
-	/** TypeChecker から得た型のテキスト表現 */
+	/** TypeChecker から得た型のテキスト表現 (関数の場合は signature 形式) */
 	type: string;
 	/** ノードに紐づくシンボル (識別子・宣言など) */
 	symbol?: SymbolInfo;
-	/** シンボルの最初の宣言位置 */
+	/** シンボルの最初の宣言位置 (alias の場合は再帰解決後の元宣言) */
 	declaration?: DeclarationLocation;
 }
 
 const NODE_TEXT_MAX_LENGTH = 80;
+const ALIAS_RESOLUTION_DEPTH_LIMIT = 16;
 
 /**
  * 指定された位置にある式・識別子の TypeChecker による推論型を取得する。
  *
- * - 識別子上 → そのシンボルの型 + 宣言位置
- * - リテラル/式上 → 型 (例: "string", "number", "{ id: string }")
- * - 空白/コメント上 → エラー
+ * - 関数/メソッド宣言を指す Identifier → 宣言テキストから組み立てた signature
+ *   (例: `(name: string) => string`、overload なら `(...) & (...)`)
+ * - 変数/プロパティ/リテラル → 推論型のテキスト (例: `{ id: string }`, `"hello"`)
+ * - 空白/コメント行など、識別子でない位置 → `nodeKind` が SourceFile や
+ *   EndOfFileToken となり、`type` はその位置で TS が返す型 (多くの場合
+ *   `typeof import("...")` 等)。エラーにはならないため、呼び出し側で
+ *   `nodeKind` を見て判定すること。
  *
  * `tsc` を都度起動するより圧倒的に速く、トークン効率も良いため、
  * Claude が能動的に「この変数の実際の型は?」を確認する用途を想定。
@@ -52,6 +62,17 @@ export function getTypeAtPosition(
 	filePath: string,
 	position: Position,
 ): GetTypeAtPositionResult {
+	if (
+		!Number.isInteger(position.line) ||
+		!Number.isInteger(position.column) ||
+		position.line < 1 ||
+		position.column < 1
+	) {
+		throw new Error(
+			`位置は 1-based の正の整数で指定してください (受信値: line=${position.line}, column=${position.column})`,
+		);
+	}
+
 	const sourceFile = project.getSourceFile(filePath);
 	if (!sourceFile) {
 		throw new Error(`ファイルが見つかりません: ${filePath}`);
@@ -69,33 +90,28 @@ export function getTypeAtPosition(
 		);
 	}
 
+	// 注: getDescendantAtPos は空白上でも SourceFile / EndOfFileToken を返すため、
+	// 「ノードが見つからない」ケースは事実上発生しない。安全のため undefined ガードのみ残す。
 	const node = sourceFile.getDescendantAtPos(offset);
 	if (!node) {
 		throw new Error(
-			`指定位置 (${position.line}:${position.column}) にノードが見つかりません (空白やコメント上を指している可能性があります)`,
+			`指定位置 (${position.line}:${position.column}) からノードを解決できません`,
 		);
 	}
 
 	const symbol = node.getSymbol();
-	// import alias の場合は元の宣言シンボルまで遡る
-	const resolvedSymbol = symbol?.getAliasedSymbol() ?? symbol;
+	const resolvedSymbol = resolveAliasChain(symbol);
 
-	// Identifier に紐づくシンボルからは、そのノード位置での実際の型 (関数シグネチャなど) を取得できる。
 	const type = resolvedSymbol
 		? resolvedSymbol.getTypeAtLocation(node)
 		: node.getType();
-	const typeText = formatTypeText(type, node);
 
-	const nodeText = node.getText();
-	const truncatedNodeText =
-		nodeText.length > NODE_TEXT_MAX_LENGTH
-			? `${nodeText.slice(0, NODE_TEXT_MAX_LENGTH)}…`
-			: nodeText;
+	const typeText = formatTypeText(type, node, resolvedSymbol);
 
 	const result: GetTypeAtPositionResult = {
 		position,
 		nodeKind: node.getKindName(),
-		nodeText: truncatedNodeText,
+		nodeText: truncateByCodePoint(node.getText(), NODE_TEXT_MAX_LENGTH),
 		type: typeText,
 	};
 
@@ -122,30 +138,121 @@ export function getTypeAtPosition(
 }
 
 /**
- * 関数宣言を指す Identifier 等は型 `typeof Foo` として表現されるため、
- * call signature を持つ場合は arrow 形式に展開して表示する。
- * 複数オーバーロードがある場合は `((...) => T) & ((...) => U)` 形式。
+ * import { x } from './a' のような alias を、`export * from './b'` を含む再エクスポート
+ * チェーンを辿って元の宣言シンボルまで再帰解決する。
  */
-function formatTypeText(type: Type, node: Node): string {
-	const raw = type.getText(node);
-	const callSignatures = type.getCallSignatures();
-	if (callSignatures.length === 0) return raw;
-	// `typeof X` 形式の場合のみ展開する (匿名関数式は既に arrow 形式)
-	if (!raw.startsWith("typeof ")) return raw;
-
-	const signatures = callSignatures.map((sig) =>
-		formatCallSignature(sig, node),
-	);
-	return signatures.length === 1
-		? signatures[0]
-		: signatures.map((s) => `(${s})`).join(" & ");
+function resolveAliasChain(
+	symbol: TsMorphSymbol | undefined,
+): TsMorphSymbol | undefined {
+	if (!symbol) return undefined;
+	let current = symbol;
+	for (let depth = 0; depth < ALIAS_RESOLUTION_DEPTH_LIMIT; depth++) {
+		const aliased = current.getAliasedSymbol();
+		if (!aliased) return current;
+		if (aliased === current) return current;
+		current = aliased;
+	}
+	return current;
 }
 
-function formatCallSignature(sig: Signature, node: Node): string {
-	const params = sig.getParameters().map((param) => {
-		const paramType = param.getTypeAtLocation(node).getText(node);
-		return `${param.getName()}: ${paramType}`;
-	});
-	const returnType = sig.getReturnType().getText(node);
-	return `(${params.join(", ")}) => ${returnType}`;
+/**
+ * 型のテキスト表現を組み立てる。
+ *
+ * - シンボルの宣言がすべて signature を持つ宣言 (FunctionDeclaration /
+ *   MethodDeclaration / MethodSignature / ArrowFunction / FunctionExpression /
+ *   CallSignature) なら、それらの宣言テキストから signature を組み立てる。
+ *   これにより rest `...` / optional `?` / 分割代入パラメータが破壊されず、
+ *   オーバーロード時には合成 `&` で連結される。
+ * - 関数 + namespace マージのような混在宣言の場合は raw を返してプロパティ側を保全する。
+ * - 上記以外 (変数・型エイリアス・リテラル等) は TypeChecker の raw text をそのまま返す。
+ */
+function formatTypeText(
+	type: Type,
+	node: Node,
+	symbol: TsMorphSymbol | undefined,
+): string {
+	const raw = type.getText(node);
+	if (!symbol) return raw;
+	const declarations = symbol.getDeclarations();
+	if (declarations.length === 0) return raw;
+
+	const signatureDecls = declarations.filter(isSignatureBearingDeclaration);
+	if (
+		signatureDecls.length === 0 ||
+		signatureDecls.length !== declarations.length
+	) {
+		// 混在 (namespace merge 等) または signature を持たない → raw を返してメンバーを保全
+		return raw;
+	}
+
+	// オーバーロードがある場合、implementation シグネチャは隠す (TS 標準の hover 挙動に合わせる)
+	const hasOverload = signatureDecls.some(
+		(decl) =>
+			(Node.isFunctionDeclaration(decl) || Node.isMethodDeclaration(decl)) &&
+			decl.isOverload(),
+	);
+	const displayDecls = hasOverload
+		? signatureDecls.filter(
+				(decl) =>
+					!(
+						(Node.isFunctionDeclaration(decl) ||
+							Node.isMethodDeclaration(decl)) &&
+						decl.isImplementation()
+					),
+			)
+		: signatureDecls;
+
+	const sigTexts = displayDecls.map(renderSignatureFromDeclaration);
+	return sigTexts.length === 1
+		? sigTexts[0]
+		: sigTexts.map((s) => `(${s})`).join(" & ");
+}
+
+function isSignatureBearingDeclaration(decl: Node): boolean {
+	return (
+		Node.isFunctionDeclaration(decl) ||
+		Node.isMethodDeclaration(decl) ||
+		Node.isMethodSignature(decl) ||
+		Node.isCallSignatureDeclaration(decl) ||
+		Node.isArrowFunction(decl) ||
+		Node.isFunctionExpression(decl) ||
+		Node.isFunctionTypeNode(decl) ||
+		Node.isGetAccessorDeclaration(decl) ||
+		Node.isSetAccessorDeclaration(decl) ||
+		Node.isConstructSignatureDeclaration(decl)
+	);
+}
+
+/**
+ * 関数様宣言から `(params) => returnType` 形式のテキストを組み立てる。
+ * パラメータと戻り値は元ソースのテキストをそのまま使うため、
+ * rest / optional / 分割代入 / readonly などの修飾子が保持される。
+ */
+function renderSignatureFromDeclaration(decl: Node): string {
+	if (!isSignatureBearingDeclaration(decl)) {
+		// 想定外: 呼び出し元でフィルタ済みのはず
+		return decl.getText();
+	}
+	const node = decl as Node & {
+		getParameters: () => Node[];
+		getReturnTypeNode?: () => Node | undefined;
+		getReturnType?: () => { getText: (n?: Node) => string };
+	};
+
+	const paramTexts = node.getParameters().map((p) => p.getText());
+	const returnTypeNode = node.getReturnTypeNode?.();
+	const returnTypeText = returnTypeNode
+		? returnTypeNode.getText()
+		: (node.getReturnType?.().getText(decl) ?? "any");
+	return `(${paramTexts.join(", ")}) => ${returnTypeText}`;
+}
+
+/**
+ * 文字列を Unicode コードポイント単位で切り詰める。
+ * UTF-16 サロゲートペア (絵文字や追加面の文字) を途中で切ることがない。
+ */
+function truncateByCodePoint(text: string, maxLength: number): string {
+	const codePoints = Array.from(text);
+	if (codePoints.length <= maxLength) return text;
+	return `${codePoints.slice(0, maxLength).join("")}…`;
 }

--- a/src/ts-morph/get-type-at-position/get-type-at-position.ts
+++ b/src/ts-morph/get-type-at-position/get-type-at-position.ts
@@ -1,0 +1,151 @@
+import type { Node, Project, Signature, Type } from "ts-morph";
+
+export interface Position {
+	/** 1-based 行番号 */
+	line: number;
+	/** 1-based 列番号 */
+	column: number;
+}
+
+export interface SymbolInfo {
+	/** シンボル名 */
+	name: string;
+	/** シンボルの最初の宣言のノード種別 (例: VariableDeclaration, FunctionDeclaration) */
+	kind: string;
+}
+
+export interface DeclarationLocation {
+	filePath: string;
+	line: number;
+	column: number;
+}
+
+export interface GetTypeAtPositionResult {
+	/** 入力された位置 */
+	position: Position;
+	/** その位置に存在するノードの SyntaxKind 名 */
+	nodeKind: string;
+	/** その位置のノードのソーステキスト (80 文字で切り詰め) */
+	nodeText: string;
+	/** TypeChecker から得た型のテキスト表現 */
+	type: string;
+	/** ノードに紐づくシンボル (識別子・宣言など) */
+	symbol?: SymbolInfo;
+	/** シンボルの最初の宣言位置 */
+	declaration?: DeclarationLocation;
+}
+
+const NODE_TEXT_MAX_LENGTH = 80;
+
+/**
+ * 指定された位置にある式・識別子の TypeChecker による推論型を取得する。
+ *
+ * - 識別子上 → そのシンボルの型 + 宣言位置
+ * - リテラル/式上 → 型 (例: "string", "number", "{ id: string }")
+ * - 空白/コメント上 → エラー
+ *
+ * `tsc` を都度起動するより圧倒的に速く、トークン効率も良いため、
+ * Claude が能動的に「この変数の実際の型は?」を確認する用途を想定。
+ */
+export function getTypeAtPosition(
+	project: Project,
+	filePath: string,
+	position: Position,
+): GetTypeAtPositionResult {
+	const sourceFile = project.getSourceFile(filePath);
+	if (!sourceFile) {
+		throw new Error(`ファイルが見つかりません: ${filePath}`);
+	}
+
+	let offset: number;
+	try {
+		offset = sourceFile.compilerNode.getPositionOfLineAndCharacter(
+			position.line - 1,
+			position.column - 1,
+		);
+	} catch (_error) {
+		throw new Error(
+			`指定位置 (${position.line}:${position.column}) はファイルの範囲外か無効です`,
+		);
+	}
+
+	const node = sourceFile.getDescendantAtPos(offset);
+	if (!node) {
+		throw new Error(
+			`指定位置 (${position.line}:${position.column}) にノードが見つかりません (空白やコメント上を指している可能性があります)`,
+		);
+	}
+
+	const symbol = node.getSymbol();
+	// import alias の場合は元の宣言シンボルまで遡る
+	const resolvedSymbol = symbol?.getAliasedSymbol() ?? symbol;
+
+	// Identifier に紐づくシンボルからは、そのノード位置での実際の型 (関数シグネチャなど) を取得できる。
+	const type = resolvedSymbol
+		? resolvedSymbol.getTypeAtLocation(node)
+		: node.getType();
+	const typeText = formatTypeText(type, node);
+
+	const nodeText = node.getText();
+	const truncatedNodeText =
+		nodeText.length > NODE_TEXT_MAX_LENGTH
+			? `${nodeText.slice(0, NODE_TEXT_MAX_LENGTH)}…`
+			: nodeText;
+
+	const result: GetTypeAtPositionResult = {
+		position,
+		nodeKind: node.getKindName(),
+		nodeText: truncatedNodeText,
+		type: typeText,
+	};
+
+	if (resolvedSymbol) {
+		const declarations = resolvedSymbol.getDeclarations();
+		const firstDeclaration = declarations[0];
+		result.symbol = {
+			name: resolvedSymbol.getName(),
+			kind: firstDeclaration?.getKindName() ?? "Unknown",
+		};
+		if (firstDeclaration) {
+			const declSourceFile = firstDeclaration.getSourceFile();
+			const declStart = firstDeclaration.getStart();
+			const { line, column } = declSourceFile.getLineAndColumnAtPos(declStart);
+			result.declaration = {
+				filePath: declSourceFile.getFilePath(),
+				line,
+				column,
+			};
+		}
+	}
+
+	return result;
+}
+
+/**
+ * 関数宣言を指す Identifier 等は型 `typeof Foo` として表現されるため、
+ * call signature を持つ場合は arrow 形式に展開して表示する。
+ * 複数オーバーロードがある場合は `((...) => T) & ((...) => U)` 形式。
+ */
+function formatTypeText(type: Type, node: Node): string {
+	const raw = type.getText(node);
+	const callSignatures = type.getCallSignatures();
+	if (callSignatures.length === 0) return raw;
+	// `typeof X` 形式の場合のみ展開する (匿名関数式は既に arrow 形式)
+	if (!raw.startsWith("typeof ")) return raw;
+
+	const signatures = callSignatures.map((sig) =>
+		formatCallSignature(sig, node),
+	);
+	return signatures.length === 1
+		? signatures[0]
+		: signatures.map((s) => `(${s})`).join(" & ");
+}
+
+function formatCallSignature(sig: Signature, node: Node): string {
+	const params = sig.getParameters().map((param) => {
+		const paramType = param.getTypeAtLocation(node).getText(node);
+		return `${param.getName()}: ${paramType}`;
+	});
+	const returnType = sig.getReturnType().getText(node);
+	return `(${params.join(", ")}) => ${returnType}`;
+}


### PR DESCRIPTION
## Summary
- issue #37 の `get_type_at_position` を実装。指定位置の TypeChecker 推論型・シンボル・宣言位置を返す情報取得系ツール。
- Claude が「この変数の実際の型は?」を `tsc` 起動 (数秒) より高速かつ低トークンで取得できることを狙う。
- 既存の refactor 系ツール (rename / move / change_signature) と並ぶ、「読む」側のツールが追加された形。

## 設計のポイント
- **1-based 行・列**: エディタ表示と同じ座標系
- **call style 展開**: 関数識別子は `typeof greet` ではなく `(name: string) => string` 形式で返す。オーバーロード複数時は `& ` で連結
- **import alias 解決**: `getAliasedSymbol()` で元の宣言シンボルまで遡り、`declaration` は元ファイルの位置を返す
- **nodeKind の透過**: 空白上を指したケースは `SourceFile` / `EndOfFileToken` として nodeKind を見れば判定可能 (エラーにはしない)
- **truncate**: nodeText は 80 文字で切り詰め (長大なオブジェクトリテラル上を指した場合の防御)

## 出力例
```
Type: { id: string; name: string; }
Node: Identifier \"user\"
Symbol: user (VariableDeclaration)
Declared at: /abs/path/file.ts:1:7
```

## 構成
- `src/ts-morph/get-type-at-position/get-type-at-position.ts` — core
- `src/ts-morph/get-type-at-position/get-type-at-position.test.ts` — 13 ケース
- `src/mcp/tools/register-get-type-at-position-tool.ts` — Zod schema + description + logger
- `ts-morph-tools.ts` に登録、`integration.test.ts` に 4 ケース追加

## Test plan
- [x] ユニット 13 + 統合 4 で計 17 ケース。プロジェクト全体 291 tests / 1 skipped 通過
- [x] \`pnpm check-types\` / \`pnpm lint\` / \`pnpm format\` クリーン
- [x] 主要シナリオを検証:
  - [x] 変数識別子・関数識別子・プロパティアクセス・呼び出し結果
  - [x] StringLiteral / NumericLiteral
  - [x] ユーザ定義ジェネリック (\`Box<string>\`)・ユニオン型
  - [x] import alias の宣言位置が元ファイル
  - [x] 型注釈位置の TypeAliasDeclaration
  - [x] 範囲外位置 / 存在しないファイルでエラー
  - [x] 空白上は SourceFile / EndOfFileToken として透過

🤖 Generated with [Claude Code](https://claude.com/claude-code)