### PR TITLE
fix(move-symbol-to-file): 逆向き import が必要なケースの AST 不整合を修正 + 実リポジトリ E2E 追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,49 @@
+name: E2E
+
+# 実リポジトリ（hono / zustand）を clone して全 MCP ツールを適用する重い E2E。
+# 毎 PR の blocking CI には入れず、nightly + 手動 dispatch で回す。
+# - 実行時間が長い（clone + 依存インストール + 各リポジトリの型チェック/テスト）
+# - bun / pnpm / ネットワークに依存する
+# silent skip（bun 不在や clone 失敗で「全 skip = 緑」）を防ぐため
+# E2E_REQUIRE_PREPARED=1 で準備失敗をハード fail にする。
+on:
+  schedule:
+    # 毎日 JST 12:00（UTC 03:00）
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      # ── 全 Action は commit SHA でピン留め（tag retag によるサプライチェーン攻撃を防ぐ）。
+      # ci.yml / release.yml と同じバージョンに揃える。
+      - name: Checkout code
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up pnpm
+        # pnpm/action-setup@v6.0.8 — version は package.json の packageManager から取る
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+
+      - name: Set up Node.js
+        # actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Set up Bun
+        # oven-sh/setup-bun@v2.2.0 — hono の依存インストールに必要
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run E2E
+        # 準備（clone/install/baseline）失敗を skip ではなく fail にする
+        env:
+          E2E_REQUIRE_PREPARED: '1'
+        run: pnpm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dist
 
 # Taskfile cache
 .task
+
+# E2E: cloned target repositories (hono 等) のキャッシュ
+e2e/.cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,28 @@ pnpm clean        # distディレクトリをクリーン
 pnpm test         # テスト実行（単一スレッドで実行）
 pnpm test:watch   # ウォッチモードでテスト実行
 pnpm test -- path/to/test.ts  # 特定のテストファイルを実行
+pnpm test:e2e     # 実リポジトリ E2E（hono/zustand を clone して全ツール適用）
 ```
+
+### E2E テスト（`pnpm test:e2e`）
+
+`e2e/` は、バージョン固定の実 OSS（hono / zustand）を clone し、各 MCP ツールを
+実プロジェクトに適用して「差分緑」（baseline と比較し新規型エラー・新規失敗テスト
+が無いこと）を検証する。ユニットテストでは拾えない実世界の AST 不整合を掘り当てる
+（例: `move_symbol_to_file` の逆向き import バグ）。
+
+- デフォルトの `pnpm test` からは除外（`vitest.config.ts` の exclude）。CI には
+  未組み込み（nightly + 手動 dispatch を予定）。
+- 初回は clone + 依存インストールが走る（`bun` / `pnpm` が必要。無ければ baseline
+  未取得で各ケース skip）。2 回目以降は `e2e/.cache/*.ready` マーカで再利用。
+- 実行時間の目安: キャッシュ有りで 2〜3 分。
+
+**Claude への指示**: `src/ts-morph/**` のリファクタロジック（特に
+`move-symbol-to-file` / `rename-*` / `remove-path-alias` / `change-signature`）に
+触れた変更は、**仕上げ段階（コミット前 / PR 化前）で `pnpm test:e2e` を実行**して
+実リポジトリで退行が無いことを確認すること。時間がかかるので開発の各イテレーション
+ではなく、まとまった作業の最後に回す。ネットワークや `bun` 不在で skip された場合は
+その旨をユーザーに伝える。
 
 ### 型チェック・リント・フォーマット
 ```bash

--- a/biome.json
+++ b/biome.json
@@ -4,7 +4,7 @@
 		"enabled": false
 	},
 	"files": {
-		"ignore": ["dist/**/*", "coverage/**/*"]
+		"ignore": ["dist/**/*", "coverage/**/*", "e2e/.cache/**/*"]
 	},
 	"linter": {
 		"enabled": true,

--- a/e2e/_child-process.ts
+++ b/e2e/_child-process.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * 子プロセス用のクリーンな環境変数。
+ * 外側 Vitest が注入する VITEST_* / NODE_OPTIONS（loader 等）を取り除き、
+ * 子の package manager / テストランナーに持ち込まないようにする。
+ *
+ * @param extra マージする追加の環境変数（例: CI / FORCE_COLOR）
+ */
+export function childEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env, ...extra };
+	for (const key of Object.keys(env)) {
+		if (key.startsWith("VITEST")) {
+			delete env[key];
+		}
+	}
+	env.NODE_OPTIONS = undefined;
+	return env;
+}
+
+export interface RunResult {
+	ok: boolean;
+	output: string;
+}
+
+/**
+ * 子プロセスを同期実行し、stdout/stderr を結合した出力と成否を返す。
+ * 依存インストールやテスト出力が大きくなるため maxBuffer を大きめに取る。
+ *
+ * @param extraEnv childEnv にマージする追加の環境変数
+ */
+export function run(
+	cmd: string,
+	args: readonly string[],
+	cwd: string,
+	extraEnv: NodeJS.ProcessEnv = {},
+): RunResult {
+	const res = spawnSync(cmd, args as string[], {
+		cwd,
+		encoding: "utf-8",
+		maxBuffer: 64 * 1024 * 1024,
+		env: childEnv(extraEnv),
+	});
+	const output = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+	if (res.error) {
+		return { ok: false, output: `${res.error.message}\n${output}` };
+	}
+	return { ok: res.status === 0, output };
+}
+
+export function commandExists(cmd: string): boolean {
+	const res = spawnSync(cmd, ["--version"], { encoding: "utf-8" });
+	return !res.error && res.status === 0;
+}

--- a/e2e/call-tool.ts
+++ b/e2e/call-tool.ts
@@ -1,0 +1,45 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTsMorphTools } from "../src/mcp/tools/ts-morph-tools";
+
+export interface ToolResult {
+	content: Array<{ type: string; text: string }>;
+	isError?: boolean;
+}
+
+type ToolHandler = (args: unknown) => Promise<ToolResult>;
+
+export interface ToolHarness {
+	callTool: (name: string, args: unknown) => Promise<ToolResult>;
+}
+
+/**
+ * 実 STDIO サーバーを介さず、登録済み MCP ツールを名前で直接呼べる軽量ハーネス。
+ * register*Tool が呼ぶ server.tool(name, description, schema, handler) を捕捉する。
+ * src/mcp/tools/integration.test.ts と同じ方式。
+ */
+export function createToolHarness(): ToolHarness {
+	const tools = new Map<string, ToolHandler>();
+
+	const mockServer = {
+		tool: (
+			name: string,
+			_description: string,
+			_schema: unknown,
+			handler: ToolHandler,
+		) => {
+			tools.set(name, handler);
+		},
+	};
+
+	registerTsMorphTools(mockServer as unknown as McpServer);
+
+	return {
+		callTool: async (name, args) => {
+			const handler = tools.get(name);
+			if (!handler) {
+				throw new Error(`[e2e] ツール '${name}' が登録されていません`);
+			}
+			return handler(args);
+		},
+	};
+}

--- a/e2e/hono.e2e.test.ts
+++ b/e2e/hono.e2e.test.ts
@@ -2,57 +2,21 @@ import { beforeAll, afterEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import { HONO } from "./targets";
 import {
-	type HealthResult,
-	type ToolResult,
 	absPath,
-	assertNoRegression,
-	checkHealth,
-	createToolHarness,
+	createScenario,
 	isWorkingTreeClean,
 	locateSymbolPosition,
-	prepareTarget,
-	resetTarget,
+	textOf,
 	tsconfigPathOf,
 } from "./scenario";
 
 const URL_FILE = "src/utils/url.ts";
 
-const harness = createToolHarness();
-let baseline: HealthResult | undefined;
+const { harness, setup, reset, requirePrepared, expectNoRegression } =
+	createScenario(HONO);
 
-beforeAll(() => {
-	try {
-		prepareTarget(HONO);
-		baseline = checkHealth(HONO);
-	} catch (e) {
-		// clone / install に失敗（ネットワーク不通や bun 不在など）した場合は
-		// baseline 未取得のまま各ケースを skip する
-		baseline = undefined;
-	}
-}, 600_000);
-
-afterEach(() => {
-	if (baseline) resetTarget(HONO);
-});
-
-/** 準備できていなければ（環境要因など）当該ケースを skip する */
-function requirePrepared(ctx: {
-	skip: (note?: string) => void;
-}): asserts baseline is HealthResult {
-	if (!baseline) {
-		ctx.skip("hono の準備（clone/install/baseline）に失敗したため skip");
-	}
-}
-
-/** リファクタ後に baseline からの退行が無いことを検証する */
-function expectNoRegression(): void {
-	const reg = assertNoRegression(baseline as HealthResult, checkHealth(HONO));
-	expect(reg.ok, reg.detail).toBe(true);
-}
-
-function textOf(result: ToolResult): string {
-	return result.content.map((c) => c.text).join("\n");
-}
+beforeAll(setup, 600_000);
+afterEach(reset);
 
 describe("hono E2E (read-only tools)", () => {
 	it("find_references: getPattern の参照を 1 件以上返す", async (ctx) => {

--- a/e2e/hono.e2e.test.ts
+++ b/e2e/hono.e2e.test.ts
@@ -1,0 +1,215 @@
+import { beforeAll, afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import { HONO } from "./targets";
+import {
+	type HealthResult,
+	type ToolResult,
+	absPath,
+	assertNoRegression,
+	checkHealth,
+	createToolHarness,
+	isWorkingTreeClean,
+	locateSymbolPosition,
+	prepareTarget,
+	resetTarget,
+	tsconfigPathOf,
+} from "./scenario";
+
+const URL_FILE = "src/utils/url.ts";
+
+const harness = createToolHarness();
+let baseline: HealthResult | undefined;
+
+beforeAll(() => {
+	try {
+		prepareTarget(HONO);
+		baseline = checkHealth(HONO);
+	} catch (e) {
+		// clone / install に失敗（ネットワーク不通や bun 不在など）した場合は
+		// baseline 未取得のまま各ケースを skip する
+		baseline = undefined;
+	}
+}, 600_000);
+
+afterEach(() => {
+	if (baseline) resetTarget(HONO);
+});
+
+/** 準備できていなければ（環境要因など）当該ケースを skip する */
+function requirePrepared(ctx: {
+	skip: (note?: string) => void;
+}): asserts baseline is HealthResult {
+	if (!baseline) {
+		ctx.skip("hono の準備（clone/install/baseline）に失敗したため skip");
+	}
+}
+
+/** リファクタ後に baseline からの退行が無いことを検証する */
+function expectNoRegression(): void {
+	const reg = assertNoRegression(baseline as HealthResult, checkHealth(HONO));
+	expect(reg.ok, reg.detail).toBe(true);
+}
+
+function textOf(result: ToolResult): string {
+	return result.content.map((c) => c.text).join("\n");
+}
+
+describe("hono E2E (read-only tools)", () => {
+	it("find_references: getPattern の参照を 1 件以上返す", async (ctx) => {
+		requirePrepared(ctx);
+		const { absFilePath, position } = locateSymbolPosition(
+			HONO,
+			URL_FILE,
+			"getPattern",
+		);
+
+		const result = await harness.callTool("find_references_by_tsmorph", {
+			tsconfigPath: tsconfigPathOf(HONO),
+			targetFilePath: absFilePath,
+			position,
+		});
+
+		expect(result.isError).toBeFalsy();
+		expect(textOf(result).toLowerCase()).toContain("reference");
+	});
+
+	it("get_type_at_position: getPattern の型情報を取得できる", async (ctx) => {
+		requirePrepared(ctx);
+		const { absFilePath, position } = locateSymbolPosition(
+			HONO,
+			URL_FILE,
+			"getPattern",
+		);
+
+		const result = await harness.callTool("get_type_at_position_by_tsmorph", {
+			tsconfigPath: tsconfigPathOf(HONO),
+			targetFilePath: absFilePath,
+			position,
+		});
+
+		expect(result.isError).toBeFalsy();
+		const text = textOf(result);
+		expect(text).toContain("Type:");
+		expect(text).toContain("getPattern");
+	});
+
+	it("find_unused_exports: エラーなく候補を列挙する", async (ctx) => {
+		requirePrepared(ctx);
+		const result = await harness.callTool("find_unused_exports_by_tsmorph", {
+			tsconfigPath: tsconfigPathOf(HONO),
+		});
+
+		expect(result.isError).toBeFalsy();
+		const text = textOf(result);
+		expect(
+			text.includes("Unused export candidates") ||
+				text.includes("No unused exports found"),
+		).toBe(true);
+	});
+});
+
+describe("hono E2E (mutating tools, 差分緑検証)", () => {
+	it("rename_symbol: getPattern を往復リネームすると元に戻る & 型/テスト緑", async (ctx) => {
+		requirePrepared(ctx);
+		const tsconfigPath = tsconfigPathOf(HONO);
+		const tmpName = "getPattern_e2e_tmp";
+
+		const forward = locateSymbolPosition(HONO, URL_FILE, "getPattern");
+		const r1 = await harness.callTool("rename_symbol_by_tsmorph", {
+			tsconfigPath,
+			targetFilePath: forward.absFilePath,
+			position: forward.position,
+			symbolName: "getPattern",
+			newName: tmpName,
+			dryRun: false,
+		});
+		expect(r1.isError).toBeFalsy();
+
+		expectNoRegression();
+
+		// 往復で元に戻す
+		const back = locateSymbolPosition(HONO, URL_FILE, tmpName);
+		const r2 = await harness.callTool("rename_symbol_by_tsmorph", {
+			tsconfigPath,
+			targetFilePath: back.absFilePath,
+			position: back.position,
+			symbolName: tmpName,
+			newName: "getPattern",
+			dryRun: false,
+		});
+		expect(r2.isError).toBeFalsy();
+		expect(isWorkingTreeClean(HONO)).toBe(true);
+	});
+
+	it("move_symbol_to_file: getPattern を別ファイルに移動しても型/テスト緑", async (ctx) => {
+		requirePrepared(ctx);
+		const targetFilePath = absPath(HONO, "src/utils/_e2e-get-pattern.ts");
+
+		const result = await harness.callTool("move_symbol_to_file_by_tsmorph", {
+			tsconfigPath: tsconfigPathOf(HONO),
+			originalFilePath: absPath(HONO, URL_FILE),
+			targetFilePath,
+			symbolToMove: "getPattern",
+			declarationKindString: "VariableStatement",
+			dryRun: false,
+		});
+
+		expect(result.isError, textOf(result)).toBeFalsy();
+		expect(fs.existsSync(targetFilePath)).toBe(true);
+
+		expectNoRegression();
+	});
+
+	// 移動元ファイルに移動シンボルへの参照が残る（= 差し戻し import が必要）ケース。
+	// splitPath は同ファイルの splitRoutingPath から参照されるため、移動先からの
+	// 逆向き import が必要になる。旧実装は fixMissingImports() で
+	// "children of the old and new trees were expected to have the same count" を
+	// 投げて失敗していた（add-back-imports-to-original-file.ts で修正済み）。
+	it("move_symbol_to_file: 移動元に参照が残る splitPath を移動しても型/テスト緑", async (ctx) => {
+		requirePrepared(ctx);
+		const targetFilePath = absPath(HONO, "src/utils/_e2e-split.ts");
+
+		const result = await harness.callTool("move_symbol_to_file_by_tsmorph", {
+			tsconfigPath: tsconfigPathOf(HONO),
+			originalFilePath: absPath(HONO, URL_FILE),
+			targetFilePath,
+			symbolToMove: "splitPath",
+			declarationKindString: "VariableStatement",
+			dryRun: false,
+		});
+
+		expect(result.isError, textOf(result)).toBeFalsy();
+		expect(fs.existsSync(targetFilePath)).toBe(true);
+
+		expectNoRegression();
+	});
+
+	it("change_signature: tryDecode に末尾引数を追加しても型/テスト緑", async (ctx) => {
+		requirePrepared(ctx);
+		const { absFilePath, position } = locateSymbolPosition(
+			HONO,
+			URL_FILE,
+			"tryDecode",
+		);
+
+		const result = await harness.callTool("change_signature_by_tsmorph", {
+			tsconfigPath: tsconfigPathOf(HONO),
+			targetFilePath: absFilePath,
+			position,
+			functionName: "tryDecode",
+			changes: [
+				{
+					kind: "add",
+					index: 2,
+					name: "_e2eFlag",
+					typeText: "boolean",
+					argumentForCallers: "false",
+				},
+			],
+			dryRun: false,
+		});
+
+		expect(result.isError, textOf(result)).toBeFalsy();
+		expectNoRegression();
+	});
+});

--- a/e2e/prepare-target.ts
+++ b/e2e/prepare-target.ts
@@ -1,42 +1,6 @@
-import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
+import { commandExists, run } from "./_child-process";
 import { E2E_CACHE_DIR, type TargetRepo, targetCheckoutDir } from "./targets";
-
-function childEnv(): NodeJS.ProcessEnv {
-	const env: NodeJS.ProcessEnv = { ...process.env };
-	for (const key of Object.keys(env)) {
-		if (key.startsWith("VITEST")) {
-			delete env[key];
-		}
-	}
-	// 外側 Vitest が注入する loader を子の package manager に持ち込まない
-	env.NODE_OPTIONS = undefined;
-	return env;
-}
-
-function run(
-	cmd: string,
-	args: readonly string[],
-	cwd: string,
-): { ok: boolean; output: string } {
-	const res = spawnSync(cmd, args as string[], {
-		cwd,
-		encoding: "utf-8",
-		// 依存インストールは時間がかかるので大きめに
-		maxBuffer: 64 * 1024 * 1024,
-		env: childEnv(),
-	});
-	const output = `${res.stdout ?? ""}${res.stderr ?? ""}`;
-	if (res.error) {
-		return { ok: false, output: `${res.error.message}\n${output}` };
-	}
-	return { ok: res.status === 0, output };
-}
-
-export function commandExists(cmd: string): boolean {
-	const res = spawnSync(cmd, ["--version"], { encoding: "utf-8" });
-	return !res.error && res.status === 0;
-}
 
 function readyMarkerPath(target: TargetRepo): string {
 	return `${targetCheckoutDir(target)}.ready`;

--- a/e2e/prepare-target.ts
+++ b/e2e/prepare-target.ts
@@ -1,0 +1,97 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import { E2E_CACHE_DIR, type TargetRepo, targetCheckoutDir } from "./targets";
+
+function childEnv(): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env };
+	for (const key of Object.keys(env)) {
+		if (key.startsWith("VITEST")) {
+			delete env[key];
+		}
+	}
+	// 外側 Vitest が注入する loader を子の package manager に持ち込まない
+	env.NODE_OPTIONS = undefined;
+	return env;
+}
+
+function run(
+	cmd: string,
+	args: readonly string[],
+	cwd: string,
+): { ok: boolean; output: string } {
+	const res = spawnSync(cmd, args as string[], {
+		cwd,
+		encoding: "utf-8",
+		// 依存インストールは時間がかかるので大きめに
+		maxBuffer: 64 * 1024 * 1024,
+		env: childEnv(),
+	});
+	const output = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+	if (res.error) {
+		return { ok: false, output: `${res.error.message}\n${output}` };
+	}
+	return { ok: res.status === 0, output };
+}
+
+export function commandExists(cmd: string): boolean {
+	const res = spawnSync(cmd, ["--version"], { encoding: "utf-8" });
+	return !res.error && res.status === 0;
+}
+
+function readyMarkerPath(target: TargetRepo): string {
+	return `${targetCheckoutDir(target)}.ready`;
+}
+
+/**
+ * 対象リポジトリを固定 commit で clone し、依存をインストールする。
+ * 既に準備済み（.ready マーカあり）なら何もせず checkout ディレクトリを返す。
+ *
+ * - 特定 commit のみを取得する shallow fetch（GitHub は SHA 指定の fetch を許可）
+ * - 依存は frozen-lockfile + ignore-scripts で固定・postinstall 不実行
+ * - .ready マーカは checkout 外に置き、scenario 間の git clean で消えないようにする
+ */
+export function prepareTarget(target: TargetRepo): string {
+	const dir = targetCheckoutDir(target);
+	const marker = readyMarkerPath(target);
+
+	if (fs.existsSync(marker) && fs.existsSync(dir)) {
+		return dir;
+	}
+
+	const pkgManager = target.installArgv[0];
+	if (!commandExists(pkgManager)) {
+		throw new Error(
+			`[e2e] パッケージマネージャ '${pkgManager}' が見つかりません（${target.name} の準備に必要）。`,
+		);
+	}
+
+	fs.mkdirSync(E2E_CACHE_DIR, { recursive: true });
+	fs.rmSync(dir, { recursive: true, force: true });
+	fs.rmSync(marker, { force: true });
+	fs.mkdirSync(dir, { recursive: true });
+
+	const steps: Array<{ cmd: string; args: string[] }> = [
+		{ cmd: "git", args: ["init", "-q"] },
+		{ cmd: "git", args: ["remote", "add", "origin", target.repoUrl] },
+		{ cmd: "git", args: ["fetch", "--depth", "1", "origin", target.commit] },
+		{ cmd: "git", args: ["checkout", "-q", "--detach", "FETCH_HEAD"] },
+	];
+	for (const step of steps) {
+		const { ok, output } = run(step.cmd, step.args, dir);
+		if (!ok) {
+			throw new Error(
+				`[e2e] ${target.name}: '${step.cmd} ${step.args.join(" ")}' に失敗しました。\n${output}`,
+			);
+		}
+	}
+
+	const { ok, output } = run(pkgManager, target.installArgv.slice(1), dir);
+	if (!ok) {
+		throw new Error(
+			`[e2e] ${target.name}: 依存インストール '${target.installArgv.join(" ")}' に失敗しました。\n${output}`,
+		);
+	}
+
+	fs.writeFileSync(marker, `${target.commit}\n${new Date().toISOString()}\n`);
+	return dir;
+}

--- a/e2e/scenario.ts
+++ b/e2e/scenario.ts
@@ -40,6 +40,16 @@ export interface TargetScenario {
 }
 
 /**
+ * E2E_REQUIRE_PREPARED が設定されているとき、準備失敗を skip ではなく fail にする。
+ * CI（nightly）で bun 不在・ネットワーク不通による「全 skip で実質ノーチェックなのに
+ * 緑」を防ぐためのガード。ローカルでは未設定なので従来どおり skip する。
+ */
+function preparationIsMandatory(): boolean {
+	const v = process.env.E2E_REQUIRE_PREPARED;
+	return v !== undefined && v !== "" && v !== "0" && v !== "false";
+}
+
+/**
  * 対象リポジトリごとの E2E シナリオ状態（harness / baseline）と、
  * 共通のライフサイクル・アサーションをまとめて生成する。
  * テストファイル側で beforeAll(setup) / afterEach(reset) を登録して使う。
@@ -54,7 +64,8 @@ export function createScenario(target: TargetRepo): TargetScenario {
 			try {
 				prepareTarget(target);
 				baseline = checkHealth(target);
-			} catch {
+			} catch (e) {
+				if (preparationIsMandatory()) throw e;
 				// clone / install に失敗（ネットワーク不通や bun 不在など）した場合は
 				// baseline 未取得のまま各ケースを skip する
 				baseline = undefined;
@@ -64,11 +75,15 @@ export function createScenario(target: TargetRepo): TargetScenario {
 			if (baseline) resetTarget(target);
 		},
 		requirePrepared(ctx) {
-			if (!baseline) {
-				ctx.skip(
-					`${target.name} の準備（clone/install/baseline）に失敗したため skip`,
+			if (baseline) return;
+			if (preparationIsMandatory()) {
+				throw new Error(
+					`${target.name} の E2E 準備に失敗しました（E2E_REQUIRE_PREPARED 設定下では skip せず fail）`,
 				);
 			}
+			ctx.skip(
+				`${target.name} の準備（clone/install/baseline）に失敗したため skip`,
+			);
 		},
 		expectNoRegression() {
 			const reg = assertNoRegression(

--- a/e2e/scenario.ts
+++ b/e2e/scenario.ts
@@ -1,0 +1,66 @@
+import { Project } from "ts-morph";
+import * as path from "node:path";
+import { targetCheckoutDir, type TargetRepo } from "./targets";
+
+export { prepareTarget } from "./prepare-target";
+export {
+	checkHealth,
+	assertNoRegression,
+	resetTarget,
+	isWorkingTreeClean,
+	type HealthResult,
+	type RegressionResult,
+} from "./verify-target";
+export { createToolHarness, type ToolResult } from "./call-tool";
+
+export interface Position {
+	line: number;
+	column: number;
+}
+
+/**
+ * 対象リポジトリ内の export 宣言の「名前識別子」の位置（1-based line/column）を
+ * ts-morph で算出する。バージョン固定なので結果は安定するが、行番号ハードコードより
+ * 読みやすく壊れにくい。
+ */
+export function locateSymbolPosition(
+	target: TargetRepo,
+	relFilePath: string,
+	symbolName: string,
+): { absFilePath: string; position: Position } {
+	const dir = targetCheckoutDir(target);
+	const tsconfigPath = path.join(dir, target.tsconfigRelPath);
+	const absFilePath = path.join(dir, relFilePath);
+
+	const project = new Project({ tsConfigFilePath: tsconfigPath });
+	const sf = project.getSourceFile(absFilePath);
+	if (!sf) {
+		throw new Error(
+			`[e2e] ${target.name}: ${relFilePath} が tsconfig(${target.tsconfigRelPath}) のプロジェクトに含まれていません`,
+		);
+	}
+
+	const decl =
+		sf.getVariableDeclaration(symbolName) ??
+		sf.getFunction(symbolName) ??
+		sf.getClass(symbolName) ??
+		sf.getInterface(symbolName) ??
+		sf.getTypeAlias(symbolName);
+	if (!decl) {
+		throw new Error(
+			`[e2e] ${target.name}: ${relFilePath} に export '${symbolName}' が見つかりません`,
+		);
+	}
+
+	const nameNode = decl.getNameNode();
+	const { line, column } = sf.getLineAndColumnAtPos(nameNode.getStart());
+	return { absFilePath, position: { line, column } };
+}
+
+export function absPath(target: TargetRepo, relPath: string): string {
+	return path.join(targetCheckoutDir(target), relPath);
+}
+
+export function tsconfigPathOf(target: TargetRepo): string {
+	return path.join(targetCheckoutDir(target), target.tsconfigRelPath);
+}

--- a/e2e/scenario.ts
+++ b/e2e/scenario.ts
@@ -1,5 +1,14 @@
+import { expect } from "vitest";
 import { Project } from "ts-morph";
 import * as path from "node:path";
+import { prepareTarget } from "./prepare-target";
+import {
+	assertNoRegression,
+	checkHealth,
+	type HealthResult,
+	resetTarget,
+} from "./verify-target";
+import { createToolHarness, type ToolResult } from "./call-tool";
 import { targetCheckoutDir, type TargetRepo } from "./targets";
 
 export { prepareTarget } from "./prepare-target";
@@ -12,6 +21,64 @@ export {
 	type RegressionResult,
 } from "./verify-target";
 export { createToolHarness, type ToolResult } from "./call-tool";
+
+/** ToolResult のテキストコンテンツを連結する。 */
+export function textOf(result: ToolResult): string {
+	return result.content.map((c) => c.text).join("\n");
+}
+
+export interface TargetScenario {
+	harness: ReturnType<typeof createToolHarness>;
+	/** 対象リポジトリを準備し baseline を取得する（beforeAll で呼ぶ）。 */
+	setup: () => void;
+	/** リファクタで変更した作業ツリーを元に戻す（afterEach で呼ぶ）。 */
+	reset: () => void;
+	/** 準備に失敗していれば当該ケースを skip する。 */
+	requirePrepared: (ctx: { skip: (note?: string) => void }) => void;
+	/** リファクタ後に baseline からの退行が無いことを検証する。 */
+	expectNoRegression: () => void;
+}
+
+/**
+ * 対象リポジトリごとの E2E シナリオ状態（harness / baseline）と、
+ * 共通のライフサイクル・アサーションをまとめて生成する。
+ * テストファイル側で beforeAll(setup) / afterEach(reset) を登録して使う。
+ */
+export function createScenario(target: TargetRepo): TargetScenario {
+	const harness = createToolHarness();
+	let baseline: HealthResult | undefined;
+
+	return {
+		harness,
+		setup() {
+			try {
+				prepareTarget(target);
+				baseline = checkHealth(target);
+			} catch {
+				// clone / install に失敗（ネットワーク不通や bun 不在など）した場合は
+				// baseline 未取得のまま各ケースを skip する
+				baseline = undefined;
+			}
+		},
+		reset() {
+			if (baseline) resetTarget(target);
+		},
+		requirePrepared(ctx) {
+			if (!baseline) {
+				ctx.skip(
+					`${target.name} の準備（clone/install/baseline）に失敗したため skip`,
+				);
+			}
+		},
+		expectNoRegression() {
+			const reg = assertNoRegression(
+				baseline as HealthResult,
+				checkHealth(target),
+			);
+			expect(reg.ok, reg.detail).toBe(true);
+		},
+	};
+}
 
 export interface Position {
 	line: number;

--- a/e2e/targets.ts
+++ b/e2e/targets.ts
@@ -1,0 +1,84 @@
+import * as path from "node:path";
+
+/**
+ * E2E の題材となる外部リポジトリの定義。
+ *
+ * バージョンは必ず固定する（commit SHA をピン留め）。tag は人間向けの目印で、
+ * 実際に checkout するのは commit。これにより上流が動いても結果が変わらない。
+ */
+export interface TargetRepo {
+	/** 識別子（キャッシュディレクトリ名にも使う） */
+	readonly name: string;
+	/** clone 元 */
+	readonly repoUrl: string;
+	/** 目印のタグ（ドキュメント用途。実体は commit で固定） */
+	readonly tag: string;
+	/** 固定する commit SHA。clone 後にこの SHA を checkout する */
+	readonly commit: string;
+	/**
+	 * MCP ツールに渡す tsconfig のリポジトリ相対パス。
+	 * project references（files:[]）な root tsconfig はソースを読み込まないため、
+	 * src 全体を include する設定を選ぶ。
+	 */
+	readonly tsconfigRelPath: string;
+	/**
+	 * 依存インストールコマンド（argv。[0] は PATH 上の package manager 実行ファイル）。
+	 * frozen-lockfile + ignore-scripts でロックファイル固定・postinstall 不実行。
+	 */
+	readonly installArgv: readonly string[];
+	/** 型チェック: 対象リポジトリの node_modules/.bin 配下の実行ファイル名と引数 */
+	readonly typecheckBin: string;
+	readonly typecheckArgs: readonly string[];
+	/**
+	 * ユニットテスト: Node で走る範囲のみ。
+	 * format/lint はリファクタ後に必ず差分が出るため検証に含めない。
+	 */
+	readonly unitTestBin: string;
+	readonly unitTestArgs: readonly string[];
+}
+
+/**
+ * hono: alias を持たない中規模リポジトリ。bun ネイティブ。
+ * rename / find-references / move / find-unused / get-type / change-signature の題材。
+ * root tsconfig は project references なので src 全体を include する tsconfig.spec.json を使う。
+ * vitest は multi-runtime 構成のため Node で走る `main` project のみ実行する。
+ */
+export const HONO: TargetRepo = {
+	name: "hono",
+	repoUrl: "https://github.com/honojs/hono.git",
+	tag: "v4.12.23",
+	commit: "83bfb3bb4a12c1d92c163a39e907df5d662ff78d",
+	tsconfigRelPath: "tsconfig.spec.json",
+	installArgv: ["bun", "install", "--frozen-lockfile", "--ignore-scripts"],
+	typecheckBin: "tsc",
+	typecheckArgs: ["--noEmit", "-p", "tsconfig.spec.json"],
+	unitTestBin: "vitest",
+	unitTestArgs: ["run", "--project", "main"],
+};
+
+/**
+ * zustand: path alias（zustand / zustand/* → ./src/*）を持つ単一パッケージ。pnpm。
+ * remove_path_alias と rename-file-system（alias 経由 import 更新）の題材。
+ * 型チェックは root tsconfig.json（src + tests を include, noEmit）。
+ */
+export const ZUSTAND: TargetRepo = {
+	name: "zustand",
+	repoUrl: "https://github.com/pmndrs/zustand.git",
+	tag: "v5.0.13",
+	commit: "6bc451efd5f0d4ef6e7b2c8d6fc6f8340562a31d",
+	tsconfigRelPath: "tsconfig.json",
+	installArgv: ["pnpm", "install", "--frozen-lockfile", "--ignore-scripts"],
+	typecheckBin: "tsc",
+	typecheckArgs: ["--noEmit"],
+	unitTestBin: "vitest",
+	unitTestArgs: ["run"],
+};
+
+export const E2E_CACHE_DIR = path.resolve(__dirname, ".cache");
+
+export function targetCheckoutDir(target: TargetRepo): string {
+	return path.join(
+		E2E_CACHE_DIR,
+		`${target.name}@${target.commit.slice(0, 12)}`,
+	);
+}

--- a/e2e/verify-target.ts
+++ b/e2e/verify-target.ts
@@ -1,7 +1,7 @@
-import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { type RunResult, run as runChild } from "./_child-process";
 import { type TargetRepo, targetCheckoutDir } from "./targets";
 
 export interface HealthResult {
@@ -17,41 +17,9 @@ function binPath(dir: string, bin: string): string {
 	return path.join(dir, "node_modules", ".bin", bin);
 }
 
-/**
- * 子プロセス用のクリーンな環境変数。
- * 外側 Vitest が注入する VITEST_* / NODE_OPTIONS（loader 等）を取り除く。
- */
-function childEnv(): NodeJS.ProcessEnv {
-	const env: NodeJS.ProcessEnv = {
-		...process.env,
-		CI: "true",
-		FORCE_COLOR: "0",
-	};
-	for (const key of Object.keys(env)) {
-		if (key.startsWith("VITEST")) {
-			delete env[key];
-		}
-	}
-	env.NODE_OPTIONS = undefined;
-	return env;
-}
-
-function run(
-	cmd: string,
-	args: readonly string[],
-	cwd: string,
-): { ok: boolean; output: string } {
-	const res = spawnSync(cmd, args as string[], {
-		cwd,
-		encoding: "utf-8",
-		maxBuffer: 64 * 1024 * 1024,
-		env: childEnv(),
-	});
-	const output = `${res.stdout ?? ""}${res.stderr ?? ""}`;
-	if (res.error) {
-		return { ok: false, output: `${res.error.message}\n${output}` };
-	}
-	return { ok: res.status === 0, output };
+/** 検証用の子プロセスは常に CI モード・色なしで実行する。 */
+function run(cmd: string, args: readonly string[], cwd: string): RunResult {
+	return runChild(cmd, args, cwd, { CI: "true", FORCE_COLOR: "0" });
 }
 
 function tail(text: string, lines = 40): string {

--- a/e2e/verify-target.ts
+++ b/e2e/verify-target.ts
@@ -1,0 +1,211 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type TargetRepo, targetCheckoutDir } from "./targets";
+
+export interface HealthResult {
+	/** tsc が報告した型エラー件数 */
+	typeErrorCount: number;
+	/** 失敗したユニットテストの識別子（"file > suite > test"）の集合 */
+	failedTests: string[];
+	/** 失敗時の診断用（型チェック・テストの出力末尾） */
+	detail: string;
+}
+
+function binPath(dir: string, bin: string): string {
+	return path.join(dir, "node_modules", ".bin", bin);
+}
+
+/**
+ * 子プロセス用のクリーンな環境変数。
+ * 外側 Vitest が注入する VITEST_* / NODE_OPTIONS（loader 等）を取り除く。
+ */
+function childEnv(): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		CI: "true",
+		FORCE_COLOR: "0",
+	};
+	for (const key of Object.keys(env)) {
+		if (key.startsWith("VITEST")) {
+			delete env[key];
+		}
+	}
+	env.NODE_OPTIONS = undefined;
+	return env;
+}
+
+function run(
+	cmd: string,
+	args: readonly string[],
+	cwd: string,
+): { ok: boolean; output: string } {
+	const res = spawnSync(cmd, args as string[], {
+		cwd,
+		encoding: "utf-8",
+		maxBuffer: 64 * 1024 * 1024,
+		env: childEnv(),
+	});
+	const output = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+	if (res.error) {
+		return { ok: false, output: `${res.error.message}\n${output}` };
+	}
+	return { ok: res.status === 0, output };
+}
+
+function tail(text: string, lines = 40): string {
+	return text.split("\n").slice(-lines).join("\n");
+}
+
+function countTypeErrors(output: string, ok: boolean): number {
+	if (ok) return 0;
+	const matches = output.match(/error TS\d+/g);
+	return matches ? matches.length : 0;
+}
+
+interface VitestJsonAssertion {
+	ancestorTitles?: string[];
+	title?: string;
+	fullName?: string;
+	status?: string;
+}
+interface VitestJsonFile {
+	name?: string;
+	assertionResults?: VitestJsonAssertion[];
+}
+interface VitestJson {
+	testResults?: VitestJsonFile[];
+}
+
+function parseFailedTests(jsonFile: string, repoDir: string): string[] {
+	if (!fs.existsSync(jsonFile)) return [];
+	let parsed: VitestJson;
+	try {
+		parsed = JSON.parse(fs.readFileSync(jsonFile, "utf-8")) as VitestJson;
+	} catch {
+		return [];
+	}
+	const failed: string[] = [];
+	for (const file of parsed.testResults ?? []) {
+		const rel = file.name ? path.relative(repoDir, file.name) : "";
+		for (const a of file.assertionResults ?? []) {
+			if (a.status === "failed") {
+				const name =
+					a.fullName ?? [...(a.ancestorTitles ?? []), a.title].join(" > ");
+				failed.push(`${rel} > ${name}`);
+			}
+		}
+	}
+	return failed.sort();
+}
+
+/**
+ * 対象リポジトリの健全性（型エラー件数 + 失敗テスト集合）を取得する。
+ * 絶対的な緑は要求せず、リファクタ前後でこの結果を比較（差分緑）する。
+ */
+export function checkHealth(target: TargetRepo): HealthResult {
+	const dir = targetCheckoutDir(target);
+
+	const type = run(
+		binPath(dir, target.typecheckBin),
+		target.typecheckArgs,
+		dir,
+	);
+
+	const jsonFile = path.join(
+		os.tmpdir(),
+		`e2e-${target.name}-${process.pid}-${Date.now()}.json`,
+	);
+	const tests = run(
+		binPath(dir, target.unitTestBin),
+		[
+			...target.unitTestArgs,
+			"--reporter=json",
+			"--outputFile",
+			jsonFile,
+			"--coverage.enabled=false",
+		],
+		dir,
+	);
+	const failedTests = parseFailedTests(jsonFile, dir);
+	fs.rmSync(jsonFile, { force: true });
+
+	return {
+		typeErrorCount: countTypeErrors(type.output, type.ok),
+		failedTests,
+		detail: [
+			`--- typecheck (${target.typecheckBin} ${target.typecheckArgs.join(" ")}) ok=${type.ok} ---`,
+			tail(type.output),
+			`--- unit tests (${target.unitTestBin} ${target.unitTestArgs.join(" ")}) exitOk=${tests.ok} failed=${failedTests.length} ---`,
+			tail(tests.output),
+		].join("\n"),
+	};
+}
+
+export interface RegressionResult {
+	ok: boolean;
+	detail: string;
+}
+
+/**
+ * リファクタ後 (after) が baseline に対して退行していないかを判定する（差分緑）。
+ * - 新規の型エラーが無い（after の型エラー件数 <= baseline）
+ * - 新規に失敗したテストが無い（after の失敗テスト ⊆ baseline の失敗テスト）
+ *
+ * baseline 時点で既に失敗している環境依存テストは退行扱いしない。
+ */
+export function assertNoRegression(
+	baseline: HealthResult,
+	after: HealthResult,
+): RegressionResult {
+	const newTypeErrors = after.typeErrorCount > baseline.typeErrorCount;
+	const baselineFailed = new Set(baseline.failedTests);
+	const newlyFailed = after.failedTests.filter((t) => !baselineFailed.has(t));
+
+	const ok = !newTypeErrors && newlyFailed.length === 0;
+	if (ok) {
+		return { ok, detail: "退行なし" };
+	}
+	return {
+		ok,
+		detail: [
+			newTypeErrors
+				? `新規の型エラー: baseline=${baseline.typeErrorCount} -> after=${after.typeErrorCount}`
+				: "",
+			newlyFailed.length > 0
+				? `新規に失敗したテスト:\n  ${newlyFailed.join("\n  ")}`
+				: "",
+			"--- after detail ---",
+			after.detail,
+		]
+			.filter(Boolean)
+			.join("\n"),
+	};
+}
+
+/**
+ * 作業ツリーが clean かどうか（rename 往復の同一性検証に使う）。
+ */
+export function isWorkingTreeClean(target: TargetRepo): boolean {
+	const dir = targetCheckoutDir(target);
+	const res = run("git", ["status", "--porcelain"], dir);
+	return res.ok && res.output.trim() === "";
+}
+
+/**
+ * リファクタで変更したファイルを git の管理状態に戻す。
+ */
+export function resetTarget(target: TargetRepo): void {
+	const dir = targetCheckoutDir(target);
+	const checkout = run("git", ["checkout", "-q", "--", "."], dir);
+	if (!checkout.ok) {
+		throw new Error(
+			`[e2e] ${target.name}: git checkout に失敗\n${checkout.output}`,
+		);
+	}
+	const clean = run("git", ["clean", "-fdq"], dir);
+	if (!clean.ok) {
+		throw new Error(`[e2e] ${target.name}: git clean に失敗\n${clean.output}`);
+	}
+}

--- a/e2e/zustand.e2e.test.ts
+++ b/e2e/zustand.e2e.test.ts
@@ -1,53 +1,13 @@
 import { beforeAll, afterEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import { ZUSTAND } from "./targets";
-import {
-	type HealthResult,
-	type ToolResult,
-	absPath,
-	assertNoRegression,
-	checkHealth,
-	createToolHarness,
-	prepareTarget,
-	resetTarget,
-	tsconfigPathOf,
-} from "./scenario";
+import { absPath, createScenario, textOf, tsconfigPathOf } from "./scenario";
 
-const harness = createToolHarness();
-let baseline: HealthResult | undefined;
+const { harness, setup, reset, requirePrepared, expectNoRegression } =
+	createScenario(ZUSTAND);
 
-beforeAll(() => {
-	try {
-		prepareTarget(ZUSTAND);
-		baseline = checkHealth(ZUSTAND);
-	} catch {
-		baseline = undefined;
-	}
-}, 600_000);
-
-afterEach(() => {
-	if (baseline) resetTarget(ZUSTAND);
-});
-
-function requirePrepared(ctx: {
-	skip: (note?: string) => void;
-}): asserts baseline is HealthResult {
-	if (!baseline) {
-		ctx.skip("zustand の準備（clone/install/baseline）に失敗したため skip");
-	}
-}
-
-function expectNoRegression(): void {
-	const reg = assertNoRegression(
-		baseline as HealthResult,
-		checkHealth(ZUSTAND),
-	);
-	expect(reg.ok, reg.detail).toBe(true);
-}
-
-function textOf(result: ToolResult): string {
-	return result.content.map((c) => c.text).join("\n");
-}
+beforeAll(setup, 600_000);
+afterEach(reset);
 
 describe("zustand E2E (alias 系, 差分緑検証)", () => {
 	it("remove_path_alias: テストの zustand エイリアス import を相対パス化しても型/テスト緑", async (ctx) => {

--- a/e2e/zustand.e2e.test.ts
+++ b/e2e/zustand.e2e.test.ts
@@ -1,0 +1,95 @@
+import { beforeAll, afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import { ZUSTAND } from "./targets";
+import {
+	type HealthResult,
+	type ToolResult,
+	absPath,
+	assertNoRegression,
+	checkHealth,
+	createToolHarness,
+	prepareTarget,
+	resetTarget,
+	tsconfigPathOf,
+} from "./scenario";
+
+const harness = createToolHarness();
+let baseline: HealthResult | undefined;
+
+beforeAll(() => {
+	try {
+		prepareTarget(ZUSTAND);
+		baseline = checkHealth(ZUSTAND);
+	} catch {
+		baseline = undefined;
+	}
+}, 600_000);
+
+afterEach(() => {
+	if (baseline) resetTarget(ZUSTAND);
+});
+
+function requirePrepared(ctx: {
+	skip: (note?: string) => void;
+}): asserts baseline is HealthResult {
+	if (!baseline) {
+		ctx.skip("zustand の準備（clone/install/baseline）に失敗したため skip");
+	}
+}
+
+function expectNoRegression(): void {
+	const reg = assertNoRegression(
+		baseline as HealthResult,
+		checkHealth(ZUSTAND),
+	);
+	expect(reg.ok, reg.detail).toBe(true);
+}
+
+function textOf(result: ToolResult): string {
+	return result.content.map((c) => c.text).join("\n");
+}
+
+describe("zustand E2E (alias 系, 差分緑検証)", () => {
+	it("remove_path_alias: テストの zustand エイリアス import を相対パス化しても型/テスト緑", async (ctx) => {
+		requirePrepared(ctx);
+		const targetPath = absPath(ZUSTAND, "tests/basic.test.tsx");
+
+		const before = fs.readFileSync(targetPath, "utf-8");
+		expect(before).toMatch(/from 'zustand'/);
+
+		const result = await harness.callTool("remove_path_alias_by_tsmorph", {
+			tsconfigPath: tsconfigPathOf(ZUSTAND),
+			targetPath,
+			dryRun: false,
+		});
+
+		expect(result.isError, textOf(result)).toBeFalsy();
+		const after = fs.readFileSync(targetPath, "utf-8");
+		// エイリアスが相対パスに置換されている
+		expect(after).not.toMatch(/from 'zustand'/);
+		expect(after).toMatch(/from '\.\.\/src/);
+
+		expectNoRegression();
+	});
+
+	it("rename_filesystem_entry: middleware ファイルをリネームして import 更新しても型/テスト緑", async (ctx) => {
+		requirePrepared(ctx);
+		const oldPath = absPath(ZUSTAND, "src/middleware/combine.ts");
+		const newPath = absPath(ZUSTAND, "src/middleware/_e2e-combine.ts");
+
+		const result = await harness.callTool(
+			"rename_filesystem_entry_by_tsmorph",
+			{
+				tsconfigPath: tsconfigPathOf(ZUSTAND),
+				renames: [{ oldPath, newPath }],
+				dryRun: false,
+			},
+		);
+
+		expect(result.isError, textOf(result)).toBeFalsy();
+		expect(fs.existsSync(newPath)).toBe(true);
+		expect(fs.existsSync(oldPath)).toBe(false);
+
+		expectNoRegression();
+	});
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"prepublishOnly": "pnpm run build",
 		"inspector": "npx @modelcontextprotocol/inspector node build/index.js",
 		"test": "vitest run --pool threads --poolOptions.threads.singleThread",
+		"test:e2e": "vitest run --config vitest.e2e.config.ts",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",
 		"check-types": "tsc --noEmit",

--- a/src/ts-morph/move-symbol-to-file/add-back-imports-to-original-file.ts
+++ b/src/ts-morph/move-symbol-to-file/add-back-imports-to-original-file.ts
@@ -1,0 +1,102 @@
+import type { SourceFile, Statement } from "ts-morph";
+import { calculateRelativePath } from "../_utils/calculate-relative-path";
+import logger from "../../utils/logger";
+import { getDeclarationIdentifier } from "./get-declaration-identifier";
+
+/**
+ * 移動対象として削除される宣言のうち、移動元ファイルに残るコードから
+ * まだ参照されているシンボル名を収集する。
+ *
+ * 削除前に呼び出す必要がある（参照解決のため宣言が存在している状態）。
+ * 戻り値の名前は、移動先ファイルからの「逆向き import」が必要なシンボル。
+ */
+export function collectSymbolsNeedingBackImport(
+	declarationsToRemove: Statement[],
+): string[] {
+	if (declarationsToRemove.length === 0) {
+		return [];
+	}
+
+	const sourceFile = declarationsToRemove[0].getSourceFile();
+	const filePath = sourceFile.getFilePath();
+	const removedRanges = declarationsToRemove.map(
+		(decl) => [decl.getStart(), decl.getEnd()] as const,
+	);
+
+	const names: string[] = [];
+	for (const declaration of declarationsToRemove) {
+		const identifier = getDeclarationIdentifier(declaration);
+		if (!identifier) {
+			continue;
+		}
+		const name = identifier.getText();
+
+		const referencedByRemainingCode = identifier
+			.findReferencesAsNodes()
+			.some((ref) => {
+				if (ref.getSourceFile().getFilePath() !== filePath) {
+					return false;
+				}
+				const pos = ref.getStart();
+				const insideRemovedDeclaration = removedRanges.some(
+					([start, end]) => pos >= start && pos < end,
+				);
+				return !insideRemovedDeclaration;
+			});
+
+		if (referencedByRemainingCode && !names.includes(name)) {
+			names.push(name);
+		}
+	}
+
+	return names;
+}
+
+/**
+ * 移動元ファイルに、移動先ファイルから指定シンボルを import する宣言を追加する。
+ * 同一モジュールへの既存 import があればマージする。
+ *
+ * ts-morph の `fixMissingImports()` は language service 経由の text 置換で
+ * AST 不整合 ("children ... same count") を起こすことがあるため、
+ * 構造的な `addImportDeclaration` で明示的に追加する。
+ */
+export function addBackImportsToOriginalFile(
+	originalSourceFile: SourceFile,
+	newFilePath: string,
+	names: string[],
+): void {
+	if (names.length === 0) {
+		return;
+	}
+
+	const moduleSpecifier = calculateRelativePath(
+		originalSourceFile.getFilePath(),
+		newFilePath,
+		{ removeExtensions: true, simplifyIndex: true },
+	);
+
+	const existing = originalSourceFile.getImportDeclaration(
+		(decl) => decl.getModuleSpecifierValue() === moduleSpecifier,
+	);
+
+	if (existing) {
+		const existingNames = new Set(
+			existing.getNamedImports().map((spec) => spec.getNameNode().getText()),
+		);
+		for (const name of names) {
+			if (!existingNames.has(name)) {
+				existing.addNamedImport(name);
+			}
+		}
+	} else {
+		originalSourceFile.addImportDeclaration({
+			moduleSpecifier,
+			namedImports: names,
+		});
+	}
+
+	logger.debug(
+		{ names, moduleSpecifier, file: originalSourceFile.getFilePath() },
+		"移動元ファイルに逆向き import を追加。",
+	);
+}

--- a/src/ts-morph/move-symbol-to-file/move-symbol-to-file.back-import.test.ts
+++ b/src/ts-morph/move-symbol-to-file/move-symbol-to-file.back-import.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { SyntaxKind } from "ts-morph";
+import { createInMemoryProjectWithDoubleQuotes } from "../_test-utils/create-in-memory-project";
+import { getFileText } from "../_test-utils/get-file-text";
+import { moveSymbolToFile } from "./move-symbol-to-file";
+
+describe("moveSymbolToFile back-import (regression)", () => {
+	// 移動元に残るシンボルが移動シンボルを参照する場合、移動先からの逆向き
+	// import を張る必要がある。旧実装は fixMissingImports() に頼っていたが、
+	// 「先頭 JSDoc + type 宣言 + 削除後の fixMissingImports」という組み合わせで
+	// ts-morph が "children of the old and new trees were expected to have the
+	// same count" を投げて失敗していた。hono の src/utils/url.ts で実際に再現。
+	it("移動元に残るコードが移動シンボルを参照する場合、逆向き import を張る", async () => {
+		const project = createInMemoryProjectWithDoubleQuotes();
+		const oldFilePath = "/src/url.ts";
+		const newFilePath = "/src/split-path.ts";
+
+		project.createSourceFile(
+			oldFilePath,
+			`/**
+ * @module
+ */
+
+export type Pattern = readonly [string, string, RegExp | true] | '*'
+export const splitPath = (path: string): string[] => {
+  return path.split("/");
+};
+export const splitRoutingPath = (routePath: string): string[] => {
+  return splitPath(routePath);
+};
+`,
+		);
+
+		await moveSymbolToFile(
+			project,
+			oldFilePath,
+			newFilePath,
+			"splitPath",
+			SyntaxKind.VariableStatement,
+		);
+
+		const oldText = getFileText(project, oldFilePath);
+		const newText = getFileText(project, newFilePath);
+
+		// 移動先に splitPath 本体がある
+		expect(newText).toContain(
+			"export const splitPath = (path: string): string[]",
+		);
+		// 移動元は宣言を持たず、逆向き import を張っている
+		expect(oldText).not.toContain("export const splitPath");
+		expect(oldText).toContain('import { splitPath } from "./split-path"');
+		// 残った参照側はそのまま
+		expect(oldText).toContain("export const splitRoutingPath");
+		expect(oldText).toContain("return splitPath(routePath)");
+	});
+
+	it("移動元の複数のシンボルが移動シンボルを参照する場合、逆向き import を 1 つにまとめる", async () => {
+		const project = createInMemoryProjectWithDoubleQuotes();
+		const oldFilePath = "/src/source.ts";
+		const newFilePath = "/src/shared.ts";
+
+		project.createSourceFile(
+			oldFilePath,
+			`export const shared = (x: number): number => x * 2;
+export const a = (x: number): number => shared(x) + 1;
+export const b = (x: number): number => shared(x) - 1;
+`,
+		);
+
+		await moveSymbolToFile(
+			project,
+			oldFilePath,
+			newFilePath,
+			"shared",
+			SyntaxKind.VariableStatement,
+		);
+
+		const oldText = getFileText(project, oldFilePath);
+		const importCount = (
+			oldText.match(/import \{ shared \} from "\.\/shared"/g) ?? []
+		).length;
+		expect(importCount).toBe(1);
+		expect(oldText).toContain("export const a");
+		expect(oldText).toContain("export const b");
+		expect(getFileText(project, newFilePath)).toContain("export const shared");
+	});
+});

--- a/src/ts-morph/move-symbol-to-file/move-symbol-to-file.ts
+++ b/src/ts-morph/move-symbol-to-file/move-symbol-to-file.ts
@@ -139,6 +139,8 @@ async function updateReferencesAndOriginalFile(
 		newFilePath,
 		symbolsNeedingBackImport,
 	);
+	// addBackImports は不足分の追加のみ行う。削除で不要になった import の除去は
+	// organizeImports が担うため、ここは整理だけでなく correctness 上も必要。
 	originalSourceFile.organizeImports();
 	logger.debug("元のファイルのインポートを整理。");
 }

--- a/src/ts-morph/move-symbol-to-file/move-symbol-to-file.ts
+++ b/src/ts-morph/move-symbol-to-file/move-symbol-to-file.ts
@@ -11,6 +11,10 @@ import {
 	prepareDeclarationStrings,
 } from "./generate-content/generate-new-source-file-content";
 import { getInternalDependencies } from "./internal-dependencies";
+import {
+	addBackImportsToOriginalFile,
+	collectSymbolsNeedingBackImport,
+} from "./add-back-imports-to-original-file";
 import { removeOriginalSymbol } from "./remove-original-symbol";
 import { updateImportsInReferencingFiles } from "./update-imports-in-referencing-files";
 import { updateTargetFile } from "./update-target-file";
@@ -123,10 +127,18 @@ async function updateReferencesAndOriginalFile(
 		...dependenciesToRemoveDeclarations,
 	];
 
+	const symbolsNeedingBackImport = collectSymbolsNeedingBackImport(
+		allDeclarationsToRemove,
+	);
+
 	removeOriginalSymbol(originalSourceFile, allDeclarationsToRemove);
 	logger.debug("元のファイルからシンボルと依存関係を削除。");
 
-	originalSourceFile.fixMissingImports();
+	addBackImportsToOriginalFile(
+		originalSourceFile,
+		newFilePath,
+		symbolsNeedingBackImport,
+	);
 	originalSourceFile.organizeImports();
 	logger.debug("元のファイルのインポートを整理。");
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "vitest/config";
 // https://vitejs.dev/config/
 export default defineConfig({
 	test: {
+		// E2E（実リポジトリ clone 系）は pnpm test:e2e で別実行する
+		exclude: ["**/node_modules/**", "**/dist/**", "e2e/**"],
 		env: {
 			API_ADDRESS: "http://localhost:8080",
 		},

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * E2E 用の Vitest 設定。
+ *
+ * 有名 OSS（hono 等）を固定バージョンで clone し、実プロジェクトに対して
+ * 各 MCP ツールを適用 → 型チェック + 対象リポジトリのユニットテストが
+ * リファクタ前後で同じ結果（差分緑）になることを検証する。
+ *
+ * clone と依存インストールを伴うため低速・ネットワーク依存。
+ * デフォルトの `pnpm test` からは除外し、`pnpm test:e2e` で明示実行する。
+ */
+export default defineConfig({
+	test: {
+		include: ["e2e/**/*.e2e.test.ts"],
+		// clone + bun install + tsc + vitest を 1 ケース内で回すため長め
+		testTimeout: 600_000,
+		hookTimeout: 600_000,
+		// 対象リポジトリの作業ディレクトリを共有するので直列実行
+		fileParallelism: false,
+		pool: "threads",
+		poolOptions: {
+			threads: {
+				singleThread: true,
+			},
+		},
+	},
+});


### PR DESCRIPTION
## Summary

- **E2E スイートを追加** (`e2e/`): バージョン固定の OSS (hono v4.12.23 / zustand v5.0.13) を clone し、各 MCP ツールを実プロジェクトに適用して「差分緑」(pristine の baseline と比較し、新規型エラー無し & 新規失敗テスト無し) を検証する。`pnpm test:e2e` で実行、デフォルトの `pnpm test` からは除外。
- **`move_symbol_to_file` のバグを修正**: この E2E が掘り当てた実バグ。移動元に「移動シンボルを参照する別シンボル」が残ると逆向き import が必要になるが、`fixMissingImports()` が ts-morph の tree-replacement と整合せず `children of the old and new trees were expected to have the same count` で落ちていた。

## 原因

移動元の残存コードが移動シンボルを参照する場合、移動先からの逆向き import を張る必要がある。旧実装はこれを `originalSourceFile.fixMissingImports()` に任せていたが、language service 経由の text 置換が incremental tree-replacement と不整合を起こして例外を投げる。最小トリガーは「先頭 JSDoc + `type` 宣言 + 移動対象の削除後に `fixMissingImports()`」の組み合わせ（hono の `src/utils/url.ts` で `splitPath` を移動すると再現）。

## 修正

- `add-back-imports-to-original-file.ts`(新規)
  - `collectSymbolsNeedingBackImport`: 削除前に `findReferencesAsNodes` で残存コードからの参照有無を判定（削除対象宣言の範囲内の参照は除外）
  - `addBackImportsToOriginalFile`: 移動先への相対パスで `addImportDeclaration`（同一モジュールの既存 import はマージ）
- `move-symbol-to-file.ts`: `fixMissingImports()` を上記に置換。不要 import 除去の `organizeImports()` は維持。

## Test plan

- [x] ユニット: 338 passed / 1 skipped（自己完結のリグレッションテスト `move-symbol-to-file.back-import.test.ts` 追加）
- [x] `pnpm check-types` / `pnpm lint` 緑
- [x] `pnpm test:e2e`: 9 件すべて緑（旧 `it.fails` だった splitPath 移動を通常テストに戻し、実 hono で差分緑を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)